### PR TITLE
feat: use dictionary instead of array

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ $ npm install @mswjs/data --save-dev
 
 ```js
 // src/mocks/db.js
-import { factory } from '@mswjs/data'
+import { factory, primaryKey } from '@mswjs/data'
 
 export const db = factory({
   user: {
-    id: () => 'abc-123',
+    id: () => primaryKey(() => 'abc-123'),
     firstName: () => 'John',
     lastName: () => 'Maverick',
   },
@@ -225,11 +225,11 @@ const popularPosts = db.post.findMany({
 #### One-to-one
 
 ```js
-import { factory, oneOf } from '@mswjs/data'
+import { factory, oneOf, primaryKey } from '@mswjs/data'
 
 const db = factory({
   user: {
-    id: String
+    id: primaryKey(String)
   },
   post: {
     it: String
@@ -252,11 +252,11 @@ db.post.create({
 
 ```js
 import { random, name } from 'faker'
-import { factory } from '@mswjs/data'
+import { factory, primaryKey } from '@mswjs/data'
 
 factory({
   user: {
-    id: random.uuid,
+    id: primaryKey(random.uuid),
     firstName: name.firstName,
   },
 })

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -1,7 +1,13 @@
 import { QuerySelector } from './query/queryTypes'
 
+export type PrimaryKeyTypes = string | number
 export type BaseTypes = string | number | boolean | Date
 export type KeyType = string | number | symbol
+
+export type PrimaryKey = {
+  primaryKey: true
+  defaultValue: () => PrimaryKeyTypes
+}
 
 export enum RelationKind {
   OneOf = 'oneOf',
@@ -41,6 +47,7 @@ export type Limit<T extends Record<string, any>> = {
   [RK in keyof T]: {
     [SK in keyof T[RK]]: T[RK][SK] extends
       | (() => BaseTypes)
+      | PrimaryKey
       | OneOf<keyof T>
       | ManyOf<keyof T>
       ? T[RK][SK]
@@ -50,6 +57,11 @@ export type Limit<T extends Record<string, any>> = {
         }
   }
 }
+
+export type ModelDeclaration = Record<
+  string,
+  (() => BaseTypes) | OneOf<any> | ManyOf<any> | PrimaryKey
+>
 
 export interface ModelAPI<
   Dictionary extends Record<string, any>,
@@ -114,4 +126,4 @@ export type Value<
     : ReturnType<T[K]>
 }
 
-export type Database<EntityType> = Record<KeyType, EntityType[]>
+export type Database<EntityType> = Record<KeyType, Map<KeyType, EntityType>>

--- a/src/model/defineRelationalProperties.ts
+++ b/src/model/defineRelationalProperties.ts
@@ -20,6 +20,7 @@ export function defineRelationalProperties(
             return acc.concat(
               executeQuery(
                 node.__type,
+                '', //we are not filtering by primaryKey
                 {
                   which: {
                     __nodeId: {

--- a/src/model/parseModelDeclaration.ts
+++ b/src/model/parseModelDeclaration.ts
@@ -2,17 +2,16 @@ import { debug } from 'debug'
 import {
   BaseTypes,
   EntityInstance,
-  ManyOf,
-  OneOf,
   RelationalNode,
   RelationKind,
+  ModelDeclaration,
 } from '../glossary'
 
 const log = debug('parseModelDeclaration')
 
 export function parseModelDeclaration(
   modelName: string,
-  declaration: Record<string, (() => BaseTypes) | OneOf<any> | ManyOf<any>>,
+  declaration: ModelDeclaration,
   initialValues?: Record<
     string,
     BaseTypes | EntityInstance<any, any> | undefined
@@ -81,6 +80,11 @@ export function parseModelDeclaration(
 
         // A plain exact initial value is provided (not a relational property).
         acc[key] = exactValue
+        return acc
+      }
+
+      if ('primaryKey' in valueGetter) {
+        acc.properties[key] = valueGetter.defaultValue()
         return acc
       }
 

--- a/src/query/executeQuery.ts
+++ b/src/query/executeQuery.ts
@@ -1,8 +1,10 @@
 import { debug } from 'debug'
-import { Database } from '../glossary'
+import { Database, KeyType } from '../glossary'
 import { compileQuery } from './compileQuery'
 import { QuerySelector } from './queryTypes'
 import { invariant } from '../utils/invariant'
+import { getComparatorsForValue } from './getComparatorsForValue'
+import { filter } from '../utils/filter'
 
 const log = debug('executeQuery')
 
@@ -12,19 +14,83 @@ const log = debug('executeQuery')
  */
 export function executeQuery(
   modelName: string,
+  primaryKey: string,
   query: QuerySelector<any>,
   db: Database<any>,
+  limit?: number,
 ) {
   log(`${JSON.stringify(query)} on "${modelName}"`)
-  const records = db[modelName]
 
   invariant(
-    records.length === 0,
+    db[modelName].size === 0,
     `Failed to execute query on the "${modelName}" model: unknown database model.`,
   )
 
-  const result = records.filter(compileQuery(query))
+  const { [primaryKey]: primaryKeyQuery, ...otherFieldsQuery } = query.which
+  const records = filterEntitesByPrimaryKey(db[modelName], primaryKey, {
+    which: { [primaryKey]: primaryKeyQuery },
+  })
+
+  const result = filter(
+    records,
+    compileQuery({ which: otherFieldsQuery }),
+    limit,
+  )
   log(`resolved query "${JSON.stringify(query)}" on "${modelName}" to`, result)
 
   return result
+}
+
+/**
+ * Filter entities by primaryKey.
+ */
+export function filterEntitesByPrimaryKey(
+  records: Map<KeyType, any>,
+  primaryKey: string,
+  query: QuerySelector<any>,
+) {
+  if (!records.size) return []
+
+  const primaryKeyQuery = query.which ? query.which[primaryKey] : null
+
+  if (!primaryKeyQuery) return Array.from(records.values())
+
+  let { filteredKeys, remainingQuery } = Object.entries(primaryKeyQuery).reduce(
+    (acc, [comparatorName, expectedValue]) => {
+      if (comparatorName === 'equals') {
+        acc.filteredKeys.push(expectedValue)
+      } else if (comparatorName === 'in' && Array.isArray(expectedValue)) {
+        acc.filteredKeys.push(...expectedValue)
+      } else {
+        acc.remainingQuery[comparatorName] = expectedValue
+      }
+      return acc
+    },
+    {
+      filteredKeys: [],
+      remainingQuery: {},
+    },
+  )
+
+  if (!filteredKeys.length) filteredKeys = Array.from(records.keys())
+
+  const ramainingQueryEntries = Object.entries(remainingQuery)
+  if (ramainingQueryEntries.length > 0) {
+    filteredKeys = filteredKeys.filter((key) => {
+      const comparatorSet = getComparatorsForValue(key)
+      return ramainingQueryEntries.reduce(
+        (acc, [comparatorName, expectedValue]) => {
+          if (!acc) return acc
+          const comparatorFn = comparatorSet[comparatorName]
+          const hasMatch = comparatorFn(expectedValue, key)
+          return hasMatch
+        },
+        true,
+      )
+    })
+  }
+
+  return filteredKeys
+    .filter((key) => records.has(key))
+    .map((key) => records.get(key))
 }

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -1,0 +1,15 @@
+export function filter<S, T extends S[]>(
+  records: T,
+  predicate: (value: S) => boolean,
+  limit?: number,
+) {
+  const filteredRecords = []
+
+  for (let i = 0; i < records.length; i++) {
+    if (limit && filteredRecords.length === limit) break
+    if (predicate(records[i])) {
+      filteredRecords.push(records[i])
+    }
+  }
+  return filteredRecords
+}

--- a/src/utils/primaryKey.ts
+++ b/src/utils/primaryKey.ts
@@ -1,0 +1,8 @@
+import { PrimaryKeyTypes, PrimaryKey } from '../glossary'
+
+export function primaryKey(defaultValue: () => PrimaryKeyTypes): PrimaryKey {
+  return {
+    primaryKey: true,
+    defaultValue,
+  }
+}

--- a/test/model/create.test.ts
+++ b/test/model/create.test.ts
@@ -1,12 +1,13 @@
-import { random } from 'faker'
+import { random, name } from 'faker'
 import { factory } from '../../src'
 import { identity } from '../../src/utils/identity'
+import { primaryKey } from '../../src/utils/primaryKey'
 
 test('creates a new entity', () => {
   const userId = random.uuid()
   const db = factory({
     user: {
-      id: identity(userId),
+      id: primaryKey(identity(userId)),
     },
   })
 
@@ -19,7 +20,7 @@ test('creates a new entity', () => {
 test('creates a new entity with initial values', () => {
   const db = factory({
     user: {
-      id: random.uuid,
+      id: primaryKey(random.uuid),
     },
   })
 
@@ -28,4 +29,54 @@ test('creates a new entity with initial values', () => {
     id: 'abc-123',
   })
   expect(exactUser).toHaveProperty('id', 'abc-123')
+})
+
+test('should create an entity with the provided key', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(random.uuid),
+    },
+  })
+
+  db.user.create({
+    id: 'abc-123',
+  })
+
+  expect(() =>
+    db.user.create({
+      id: 'abc-123',
+    }),
+  ).toThrow(
+    'Failed to create a "user" entity with the primary key "id": an entity with such key already exists.',
+  )
+})
+
+test('should throw an error if an entity is created with multiple primary key', () => {
+  expect(() =>
+    factory({
+      user: {
+        id: primaryKey(random.uuid),
+        uuid: primaryKey(random.uuid),
+      },
+    }),
+  ).toThrowError('You cannot specify more than one key for model "user"')
+})
+
+test('every model should have a primary key', () => {
+  expect(() => {
+    factory({
+      user: {
+        firstName: () => 'John',
+      },
+    })
+  })
+    .toThrow(`The model "user" doesn't have a primary key. You can add it using the util function \`primaryKey\`
+
+import { factory, primaryKey } from '@mswjs/data'
+
+const db = factory({
+  user: {
+    id: primaryKey(random.uuid),
+  },
+})`)
 })

--- a/test/model/delete.test.ts
+++ b/test/model/delete.test.ts
@@ -1,11 +1,12 @@
 import { random, name } from 'faker'
 import { factory } from '../../src'
+import { primaryKey } from '../../src/utils/primaryKey'
 
 test('deletes a unique entity that matches the query', () => {
   const userId = random.uuid()
   const db = factory({
     user: {
-      id: random.uuid,
+      id: primaryKey(random.uuid),
       firstName: name.findName,
     },
   })
@@ -32,6 +33,7 @@ test('deletes a unique entity that matches the query', () => {
 test('deletes the first entity that matches the query', () => {
   const db = factory({
     user: {
+      id: primaryKey(random.uuid),
       firstName: name.firstName,
       followersCount: Number,
     },
@@ -67,7 +69,7 @@ test('deletes the first entity that matches the query', () => {
 test('does nothing when no entity matches the query', () => {
   const db = factory({
     user: {
-      id: random.uuid,
+      id: primaryKey(random.uuid),
       firstName: name.firstName,
     },
   })

--- a/test/model/deleteMany.test.ts
+++ b/test/model/deleteMany.test.ts
@@ -1,9 +1,11 @@
 import { random, name } from 'faker'
 import { factory } from '../../src'
+import { primaryKey } from '../../src/utils/primaryKey'
 
 test('deletes all entites that match the query', () => {
   const db = factory({
     user: {
+      id: primaryKey(random.uuid),
       firstName: name.firstName,
       followersCount: random.number,
     },
@@ -57,6 +59,7 @@ test('deletes all entites that match the query', () => {
 test('does nothing when no entities match the query', () => {
   const db = factory({
     user: {
+      id: primaryKey(random.uuid),
       firstName: name.firstName,
       followersCount: random.number,
     },

--- a/test/model/findFirst.test.ts
+++ b/test/model/findFirst.test.ts
@@ -1,12 +1,13 @@
 import { random } from 'faker'
 import { factory } from '../../src'
 import { identity } from '../../src/utils/identity'
+import { primaryKey } from '../../src/utils/primaryKey'
 
 test('returns the only matching entity', () => {
   const userId = random.uuid()
   const db = factory({
     user: {
-      id: identity(userId),
+      id: primaryKey(identity(userId)),
     },
   })
 
@@ -25,7 +26,7 @@ test('returns the only matching entity', () => {
 test('returns the first entity among multiple matching entities', () => {
   const db = factory({
     user: {
-      id: random.uuid,
+      id: primaryKey(random.uuid),
       followersCount: Number,
     },
   })
@@ -47,7 +48,7 @@ test('returns the first entity among multiple matching entities', () => {
 test('returns null when found no matching entities', () => {
   const db = factory({
     user: {
-      id: random.uuid,
+      id: primaryKey(random.uuid),
     },
   })
   db.user.create()

--- a/test/model/findMany.test.ts
+++ b/test/model/findMany.test.ts
@@ -1,10 +1,11 @@
 import { random } from 'faker'
 import { factory } from '../../src'
+import { primaryKey } from '../../src/utils/primaryKey'
 
 test('returns the first entity among multiple matching entities', () => {
   const db = factory({
     user: {
-      id: random.uuid,
+      id: primaryKey(random.uuid),
       followersCount: Number,
     },
   })
@@ -28,7 +29,7 @@ test('returns the first entity among multiple matching entities', () => {
 test('returns an empty array when not found matching entities', () => {
   const db = factory({
     user: {
-      id: random.uuid,
+      id: primaryKey(random.uuid),
       followersCount: Number,
     },
   })

--- a/test/model/getAll.test.ts
+++ b/test/model/getAll.test.ts
@@ -1,10 +1,11 @@
 import { random } from 'faker'
 import { factory } from '../../src'
+import { primaryKey } from '../../src/utils/primaryKey'
 
 test('returns all entities', () => {
   const db = factory({
     user: {
-      id: random.uuid,
+      id: primaryKey(random.uuid),
       firstName: String,
     },
   })
@@ -23,7 +24,7 @@ test('returns all entities', () => {
 test('returns an empty list when found no entities', () => {
   const db = factory({
     user: {
-      id: random.uuid,
+      id: primaryKey(random.uuid),
       firstName: String,
     },
   })

--- a/test/query/boolean.test.ts
+++ b/test/query/boolean.test.ts
@@ -1,8 +1,11 @@
+import { random } from 'faker'
 import { factory } from '../../src'
+import { primaryKey } from '../../src/utils/primaryKey'
 
 test('queries entities based on a boolean value', () => {
   const db = factory({
     book: {
+      id: primaryKey(random.uuid),
       title: String,
       published: Boolean,
     },

--- a/test/query/date.test.ts
+++ b/test/query/date.test.ts
@@ -1,8 +1,11 @@
+import { random } from 'faker'
 import { factory } from '../../src'
+import { primaryKey } from '../../src/utils/primaryKey'
 
 const setup = () => {
   const db = factory({
     user: {
+      id: primaryKey(random.uuid),
       firstName: String,
       createdAt: () => new Date(),
     },

--- a/test/query/filterByPrimaryKey.test.ts
+++ b/test/query/filterByPrimaryKey.test.ts
@@ -1,0 +1,89 @@
+import { filterEntitesByPrimaryKey } from '../../src/query/executeQuery'
+
+const createEntities = (size: number) => {
+  return Array.from(Array(size).keys())
+    .reverse()
+    .reduce<Map<number, Record<string, any>>>((acc, id) => {
+      acc.set(id, {
+        id,
+      })
+
+      return acc
+    }, new Map<number, Record<string, any>>())
+}
+
+test('should return all elements if query is not provided', () => {
+  const entities = createEntities(1)
+  const filteredEntities = filterEntitesByPrimaryKey(entities, 'id', {
+    which: null,
+  })
+
+  expect(filteredEntities).toHaveLength(1)
+  expect(filteredEntities).toEqual(Array.from(entities.values()))
+})
+
+test('should find the entity by id', () => {
+  const entities = createEntities(15)
+  const filteredEntities = filterEntitesByPrimaryKey(entities, 'id', {
+    which: {
+      id: {
+        equals: 14,
+      },
+    },
+  })
+
+  expect(filteredEntities).toHaveLength(1)
+  expect(filteredEntities).toEqual([
+    {
+      id: 14,
+    },
+  ])
+})
+
+test('should find entities in a range', () => {
+  const entities = createEntities(100)
+  const filteredEntities = filterEntitesByPrimaryKey(entities, 'id', {
+    which: {
+      id: {
+        in: [2, 25, 50],
+      },
+    },
+  })
+
+  expect(filteredEntities).toHaveLength(3)
+  expect(filteredEntities).toEqual([
+    {
+      id: 2,
+    },
+    {
+      id: 25,
+    },
+    {
+      id: 50,
+    },
+  ])
+})
+
+test('should find entities in a range', () => {
+  const entities = createEntities(10)
+  const filteredEntities = filterEntitesByPrimaryKey(entities, 'id', {
+    which: {
+      id: {
+        between: [1, 3],
+      },
+    },
+  })
+
+  expect(filteredEntities).toHaveLength(3)
+  expect(filteredEntities).toEqual([
+    {
+      id: 3,
+    },
+    {
+      id: 2,
+    },
+    {
+      id: 1,
+    },
+  ])
+})

--- a/test/query/number.test.ts
+++ b/test/query/number.test.ts
@@ -1,8 +1,11 @@
+import { random } from 'faker'
 import { factory } from '../../src'
+import { primaryKey } from '../../src/utils/primaryKey'
 
 const setup = () => {
   const db = factory({
     user: {
+      id: primaryKey(random.uuid),
       firstName: String,
       age: Number,
     },

--- a/test/query/string.test.ts
+++ b/test/query/string.test.ts
@@ -1,8 +1,11 @@
+import { random } from 'faker'
 import { factory } from '../../src'
+import { primaryKey } from '../../src/utils/primaryKey'
 
 const setup = () => {
   const db = factory({
     recipe: {
+      id: primaryKey(random.uuid),
       title: String,
       category: String,
     },

--- a/test/relations/many-to-one.test.ts
+++ b/test/relations/many-to-one.test.ts
@@ -1,15 +1,17 @@
 import { random, name } from 'faker'
 import { factory, oneOf } from '../../src'
 import { identity } from '../../src/utils/identity'
+import { primaryKey } from '../../src/utils/primaryKey'
 
 test('supports querying against a many-to-one relation', () => {
   const userId = random.uuid()
   const db = factory({
     user: {
-      id: identity(userId),
+      id: primaryKey(identity(userId)),
       firstName: name.firstName,
     },
     post: {
+      id: primaryKey(random.uuid),
       title: random.words,
       author: oneOf('user'),
     },
@@ -47,13 +49,16 @@ test('supports querying against a many-to-one relation', () => {
 test('supports querying against nested relational properties', () => {
   const db = factory({
     role: {
+      id: primaryKey(random.uuid),
       title: random.word,
     },
     user: {
+      id: primaryKey(random.uuid),
       firstName: name.firstName,
       role: oneOf('role'),
     },
     post: {
+      id: primaryKey(random.uuid),
       title: random.words,
       author: oneOf('user'),
     },

--- a/test/relations/one-to-many.test.ts
+++ b/test/relations/one-to-many.test.ts
@@ -1,12 +1,15 @@
 import { random } from 'faker'
 import { factory, manyOf } from '../../src'
+import { primaryKey } from '../../src/utils/primaryKey'
 
 test('supports one-to-many relation', () => {
   const db = factory({
     user: {
+      id: primaryKey(random.uuid),
       posts: manyOf('post'),
     },
     post: {
+      id: primaryKey(random.uuid),
       title: random.words,
     },
   })

--- a/test/relations/one-to-one.test.ts
+++ b/test/relations/one-to-one.test.ts
@@ -1,12 +1,15 @@
 import { random } from 'faker'
 import { factory, oneOf } from '../../src'
+import { primaryKey } from '../../src/utils/primaryKey'
 
 test('supports one-to-one relation', () => {
   const db = factory({
     country: {
+      id: primaryKey(random.uuid),
       name: random.words,
     },
     capital: {
+      id: primaryKey(random.uuid),
       name: random.word,
       country: oneOf('country'),
     },
@@ -26,9 +29,11 @@ test('supports one-to-one relation', () => {
 test('supports querying through a one-to-one relational property', () => {
   const db = factory({
     country: {
+      id: primaryKey(random.uuid),
       name: random.words,
     },
     capital: {
+      id: primaryKey(random.uuid),
       name: random.word,
       country: oneOf('country'),
     },
@@ -37,7 +42,7 @@ test('supports querying through a one-to-one relational property', () => {
   const usa = db.country.create({
     name: 'United States of America',
   })
-  const washington = db.capital.create({
+  db.capital.create({
     name: 'Washington',
     country: usa,
   })


### PR DESCRIPTION
close #13 

This is a draft PR. When a new entity is created the user could choose a primary key. If no one key is specified an `id` key is created.

I have added a method `filter` that can be used for #4 


- [x] Add `primaryKey` utility method
- [x] Use `id` if no primaryKey is specified
- [x] Consinstences checks
- [x] Search using the `primaryKey`
- [x] Tests