### PR TITLE
Supports "createMany" model method

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -88,12 +88,9 @@ function createModelApi<
               if ('__type' in propDeclaration) {
                 const isManyOfRelationType =
                   propDeclaration.__type === RelationKind.ManyOf
-                const resolvedCount = isManyOfRelationType
-                  ? (count as number)
-                  : 1
                 const relationalModel = factory[propDeclaration.modelName]
                 const records = isManyOfRelationType
-                  ? relationalModel.createMany(resolvedCount)
+                  ? relationalModel.createMany(count as number)
                   : relationalModel.create()
 
                 acc[key] = records

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -106,6 +106,14 @@ export interface ModelAPI<
     initialValues?: Partial<Value<Dictionary[ModelName], Dictionary>>,
   ): EntityInstance<Dictionary, ModelName>
   /**
+   * Create multiple entities for the model.
+   * @param count Amount of models to create.
+   */
+  createMany(
+    count?: number,
+    options?: CreateManyOptions<Dictionary[ModelName]>,
+  ): EntityInstance<Dictionary, ModelName>[]
+  /**
    * Return the total number of entities.
    */
   count(query?: QuerySelector<Value<Dictionary[ModelName], Dictionary>>): number
@@ -180,6 +188,21 @@ export type Value<
     : T[K] extends PrimaryKeyDeclaration
     ? ReturnType<T[K]['getValue']>
     : ReturnType<T[K]>
+}
+
+type SubType<P, Condition> = Pick<
+  P,
+  {
+    [K in keyof P]: P[K] extends Condition ? K : never
+  }[keyof P]
+>
+
+interface CreateManyOptions<T extends Record<string, any>> {
+  relations: {
+    [K in keyof SubType<T, OneOf<any> | ManyOf<any>>]: T[K] extends ManyOf<any>
+      ? number
+      : boolean
+  }
 }
 
 export type Database = Record<KeyType, Map<string, EntityInstance<any, any>>>

--- a/src/utils/getRandomNumber.ts
+++ b/src/utils/getRandomNumber.ts
@@ -1,0 +1,8 @@
+/**
+ * Return a random number in range.
+ * @param min The lowest number to return.
+ * @param max The highest number to return.
+ */
+export function getRandomNumber(min: number = 5, max: number = 50) {
+  return Math.floor(Math.random() * (max - min + 1) + min)
+}

--- a/test/model/createMany.test.ts
+++ b/test/model/createMany.test.ts
@@ -1,0 +1,64 @@
+import { name, random } from 'faker'
+import { factory, manyOf, oneOf, primaryKey } from '../../src'
+
+test('creates multiple entities with a fixed count', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(random.uuid),
+      firstName: name.firstName,
+    },
+  })
+
+  db.user.createMany(5)
+
+  const allUsers = db.user.getAll()
+  expect(allUsers).toHaveLength(5)
+})
+
+test('allows to specify count of relational entities to create', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(random.uuid),
+      country: oneOf('country'),
+      posts: manyOf('post'),
+    },
+    post: {
+      id: primaryKey(random.uuid),
+      title: random.words,
+    },
+    country: {
+      id: primaryKey(random.uuid),
+      name: random.word,
+    },
+  })
+
+  db.user.createMany(3, {
+    relations: {
+      /**
+       * @todo How to specify that multiple entities should reuse the same relational model?
+       * I.e. multiple users from the same country.
+       *
+       * @todo `Boolean` value of `oneOf` relation has no sense:
+       * an entity cannot be created without all relational models specified.
+       */
+      country: false,
+      posts: 2,
+    },
+  })
+
+  const allUsers = db.user.getAll()
+  const allPosts = db.post.getAll()
+  const allCountries = db.country.getAll()
+
+  expect(allUsers).toHaveLength(3)
+  // Each of 3 random "user" should have "2" posts created.
+  expect(allPosts).toHaveLength(6)
+  // Each of 3 random "user" should have its own "country".
+  expect(allCountries).toHaveLength(3)
+
+  allUsers.forEach((user, index) => {
+    expect(user.posts).toHaveLength(2)
+    expect(user.country).toHaveProperty('id', allCountries[index].id)
+    expect(user.country).toHaveProperty('name', allCountries[index].name)
+  })
+})


### PR DESCRIPTION
## GitHub

- Closes #31 

## Changes

- [x] Adds `createMany` model method to create multiple random instances of the model.
- [ ] Supports multiple randomly created entities that reference the same relational model (#34).
- [ ] Type annotates a `oneOf` relational property when listing the `options.relations` in `createMany` (cannot create an entity without all its relational models specified, so `boolean` makes no sense).
- [ ] Supports creation of nested relational properties (user -> post -> category).