### PR TITLE
Uses primary key as the "__nodeId"

### DIFF
--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -17,7 +17,11 @@ export enum RelationKind {
 export interface RelationalNode<ModelName extends string> {
   kind: RelationKind
   modelName: string
-  nodes: Array<InternalEntityProperties<ModelName>>
+  nodes: Array<
+    InternalEntityProperties<ModelName> & {
+      __nodeId: PrimaryKeyType
+    }
+  >
 }
 
 export type OneOf<T extends KeyType> = {
@@ -41,7 +45,6 @@ export type FactoryAPI<Dictionary extends Record<string, any>> = {
 
 export interface InternalEntityProperties<ModelName extends KeyType> {
   readonly __type: ModelName
-  readonly __nodeId: string
   readonly __primaryKey: PrimaryKeyType
 }
 

--- a/src/model/createModel.ts
+++ b/src/model/createModel.ts
@@ -25,7 +25,6 @@ export function createModel<
 
   const internalProperties: InternalEntityProperties<ModelName> = {
     __type: modelName,
-    __nodeId: v4(),
     __primaryKey: primaryKey,
   }
   const model = Object.assign({}, properties, internalProperties)

--- a/src/model/defineRelationalProperties.ts
+++ b/src/model/defineRelationalProperties.ts
@@ -16,15 +16,15 @@ export function defineRelationalProperties(
         get() {
           log(`get "${property}"`, relation)
 
-          const refResults = relation.nodes.reduce((acc, node) => {
+          const refResults = relation.nodes.reduce((acc, relationNode) => {
             return acc.concat(
               executeQuery(
-                node.__type,
-                null,
+                relationNode.__type,
+                relationNode.__primaryKey,
                 {
                   which: {
-                    __nodeId: {
-                      equals: node.__nodeId,
+                    [relationNode.__primaryKey]: {
+                      equals: relationNode.__nodeId,
                     },
                   },
                 },

--- a/src/model/parseModelDeclaration.ts
+++ b/src/model/parseModelDeclaration.ts
@@ -6,6 +6,7 @@ import {
   Value,
   ModelDeclaration,
   PrimaryKeyType,
+  EntityInstance,
 } from '../glossary'
 import { invariant } from '../utils/invariant'
 
@@ -73,20 +74,25 @@ export function parseModelDeclaration<
           acc.relations[key] = {
             kind: RelationKind.ManyOf,
             modelName: key,
-            nodes: exactValue.map((relation) => ({
-              __type: relation.__type,
-              __nodeId: relation.__nodeId,
-            })),
+            nodes: exactValue.map(
+              (nodeRef: EntityInstance<Dictionary, ModelName>) => ({
+                __type: nodeRef.__type,
+                __primaryKey: nodeRef.__primaryKey,
+                __nodeId: nodeRef[nodeRef.__primaryKey],
+              }),
+            ),
           }
 
           return acc
         }
 
-        if ('__nodeId' in exactValue) {
-          const relation = exactValue
+        if ('__primaryKey' in exactValue) {
+          const nodeRef = exactValue
 
           log(
-            `initial value for "${modelName}.${key}" references "${relation.__type}" with id "${relation.__nodeId}"`,
+            `initial value for "${modelName}.${key}" references "${
+              nodeRef.__type
+            }" with id "${nodeRef[nodeRef.__primaryKey]}"`,
           )
 
           acc.relations[key] = {
@@ -94,9 +100,9 @@ export function parseModelDeclaration<
             modelName: key,
             nodes: [
               {
-                __type: relation.__type,
-                __nodeId: relation.__nodeId,
-                __primaryKey: 'PRIMARY_KEY',
+                __type: nodeRef.__type,
+                __primaryKey: nodeRef.__primaryKey,
+                __nodeId: nodeRef[nodeRef.__primaryKey],
               },
             ],
           }


### PR DESCRIPTION
## GitHub

- Closes #39 

## Changes

- `__nodeId` is no longer generated when creating a model. 
- `__nodeId` is no longer an internal entity property. Its value can be derived from `node[node.__primaryKey]`, so no need to duplicate it.
- `__nodeId` now equals `nodeRef[nodeRef.__primaryKey]` when one record is provided as a value of another record's property value.
- Now we _do_ query by the primary key when resolving relational properties. This should also make the process slightly faster. 

> Removing the value (`__nodeId`) of the referenced node isn't possible, because at the moment of resolving the reference the referenced node is gone, as it was replaced by a relation node upon declaring the model. This means that the _relation node_ must include the exact value of the `__primaryKey` value. 