### PR TITLE
compileQuery: Supports querying through Array of values

### DIFF
--- a/test/model/findMany.test.ts
+++ b/test/model/findMany.test.ts
@@ -3,7 +3,7 @@ import { factory, primaryKey } from '../../src'
 import { OperationErrorType } from '../../src/errors/OperationError'
 import { getThrownError } from '../testUtils'
 
-test('returns the first entity among multiple matching entities', () => {
+test('returns all matching entities', () => {
   const db = factory({
     user: {
       id: primaryKey(random.uuid),

--- a/test/relations/one-to-many.test.ts
+++ b/test/relations/one-to-many.test.ts
@@ -28,3 +28,51 @@ test('supports one-to-many relation', () => {
   const posts = user.posts.map((post) => post.title)
   expect(posts).toEqual(['First post', 'Second post'])
 })
+
+test('supports querying through one-to-many relation', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(String),
+      posts: manyOf('post'),
+    },
+    post: {
+      id: primaryKey(random.uuid),
+      title: random.words,
+    },
+  })
+
+  db.user.create({
+    id: 'user-1',
+    posts: [
+      db.post.create({ title: 'First post' }),
+      db.post.create({ title: 'Second post' }),
+    ],
+  })
+
+  db.user.create({
+    id: 'user-2',
+    posts: [db.post.create({ title: 'Third post' })],
+  })
+
+  db.user.create({
+    id: 'user-3',
+    posts: [
+      db.post.create({ title: 'Second post' }),
+      db.post.create({ title: 'Fourth post' }),
+    ],
+  })
+
+  const users = db.user.findMany({
+    which: {
+      posts: {
+        title: {
+          in: ['First post', 'Second post'],
+        },
+      },
+    },
+  })
+  expect(users).toHaveLength(2)
+
+  const userIds = users.map((user) => user.id)
+  expect(userIds).toEqual(['user-1', 'user-3'])
+})


### PR DESCRIPTION
- Closes #46 
- Pre-requisite for #47 

## Changes

- Query can now be compiled against an Array of values. In that case, if at least one of the array items matches the query, the entire entity is considered matching. 

> CAUTION: This means that the default behavior for multi-criteria querying is `OR`. There's currently no API to support the `AND` query condition. 