### PR TITLE
update: Provide the whole entity as an argument

### DIFF
--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -131,7 +131,7 @@ export interface ModelAPI<
    */
   update(
     query: QuerySelector<Value<Dictionary[ModelName], Dictionary>> & {
-      data: Partial<Value<Dictionary[ModelName], Dictionary>>
+      data: Partial<UpdateManyValue<Dictionary[ModelName], Dictionary>>
     },
   ): EntityInstance<Dictionary, ModelName>
   /**
@@ -165,8 +165,12 @@ export type UpdateManyValue<
       [K in keyof T]: T[K] extends PrimaryKeyDeclaration
         ? (
             prevValue: ReturnType<T[K]['getValue']>,
+            entity: Value<T, Parent>,
           ) => ReturnType<T[K]['getValue']>
-        : (prevValue: ReturnType<T[K]>) => ReturnType<T[K]>
+        : (
+            prevValue: ReturnType<T[K]>,
+            entity: Value<T, Parent>,
+          ) => ReturnType<T[K]>
     }
 
 export type Value<

--- a/src/model/updateEntity.ts
+++ b/src/model/updateEntity.ts
@@ -16,7 +16,7 @@ export function updateEntity(
       return acc
     }
 
-    acc[key] = typeof value === 'function' ? value(entity[key]) : value
+    acc[key] = typeof value === 'function' ? value(entity[key], entity) : value
     return acc
   }, {})
 


### PR DESCRIPTION
## Change

Enables access to the entire entity state at the moment of update when evolving next values:

```js
db.user.update({
  which: {
    role: {
      equals: 'Auditor',
    },
  },
  data: {
    firstName(firstName) {
      return firstName.toUpperCase()
    },
    // Can now access the entire "user" to derive the next "role" value.
    role(role, user) {
      return user.firstName === 'John' ? 'Writer' : role
    },
  },
})
```

The exposed entity is a _non-modified_ entity, not yet updated. 