### PR TITLE
Removes internal properties from the handlers responses

### DIFF
--- a/src/model/generateHandlers.ts
+++ b/src/model/generateHandlers.ts
@@ -8,6 +8,7 @@ import {
 } from '../glossary'
 import { GetQueryFor } from '../query/queryTypes'
 import { OperationErrorType, OperationError } from '../errors/OperationError'
+import { removeInternalProperties } from '../utils/removeInternalProperties'
 
 interface WeakQuerySelectorWhich<KeyType extends PrimaryKeyType> {
   [key: string]: Partial<GetQueryFor<KeyType>>
@@ -82,7 +83,7 @@ export function generateHandlers<
 
         const records = model.findMany(options)
 
-        return res(ctx.json(records))
+        return res(ctx.json(records.map(removeInternalProperties)))
       }),
     ),
     rest.get(
@@ -99,14 +100,17 @@ export function generateHandlers<
           which: which as any,
         })
 
-        return res(ctx.json(entity))
+        return res(ctx.json(removeInternalProperties(entity)))
       }),
     ),
     rest.post(
       buildUrl(modelPath),
       withErrors<EntityInstance<Dictionary, ModelName>>((req, res, ctx) => {
         const createdEntity = model.create(req.body)
-        return res(ctx.status(201), ctx.json(createdEntity))
+        return res(
+          ctx.status(201),
+          ctx.json(removeInternalProperties(createdEntity)),
+        )
       }),
     ),
     rest.put(
@@ -125,7 +129,7 @@ export function generateHandlers<
             data: req.body,
           })
 
-          return res(ctx.json(updatedEntity))
+          return res(ctx.json(removeInternalProperties(updatedEntity)))
         },
       ),
     ),
@@ -144,7 +148,7 @@ export function generateHandlers<
             which: which as any,
           })
 
-          return res(ctx.json(deletedEntity))
+          return res(ctx.json(removeInternalProperties(deletedEntity)))
         },
       ),
     ),

--- a/src/utils/removeInternalProperties.ts
+++ b/src/utils/removeInternalProperties.ts
@@ -1,0 +1,16 @@
+import { EntityInstance, InternalEntityProperties } from '../glossary'
+
+/**
+ * Remove internal properties from the given entity.
+ */
+export function removeInternalProperties<
+  Entity extends EntityInstance<any, any>
+>(entity: Entity): Omit<Entity, keyof InternalEntityProperties<any>> {
+  return Object.entries(entity).reduce<any>((result, [key, value]) => {
+    if (!key.startsWith('__')) {
+      result[key] = value
+    }
+
+    return result
+  }, {})
+}

--- a/test/model/toHandlers.test.ts
+++ b/test/model/toHandlers.test.ts
@@ -56,11 +56,16 @@ describe('GET /users', () => {
     const users = await res.json()
 
     expect(res.status).toEqual(200)
-    expect(users).toHaveLength(2)
-    expect(users[0]).toHaveProperty('id', 'abc-123')
-    expect(users[0]).toHaveProperty('firstName', 'John')
-    expect(users[1]).toHaveProperty('id', 'def-456')
-    expect(users[1]).toHaveProperty('firstName', 'Kate')
+    expect(users).toEqual([
+      {
+        id: 'abc-123',
+        firstName: 'John',
+      },
+      {
+        id: 'def-456',
+        firstName: 'Kate',
+      },
+    ])
   })
 
   it('returns offset paginated entities', async () => {
@@ -85,11 +90,16 @@ describe('GET /users', () => {
     const res = await fetch('http://localhost/users?skip=1&take=2')
     const users = await res.json()
 
-    expect(users).toHaveLength(2)
-    expect(users[0]).toHaveProperty('id', 'def-456')
-    expect(users[0]).toHaveProperty('firstName', 'Kate')
-    expect(users[1]).toHaveProperty('id', 'ghi-789')
-    expect(users[1]).toHaveProperty('firstName', 'Joseph')
+    expect(users).toEqual([
+      {
+        id: 'def-456',
+        firstName: 'Kate',
+      },
+      {
+        id: 'ghi-789',
+        firstName: 'Joseph',
+      },
+    ])
   })
 
   it('returns cursor paginated entities', async () => {
@@ -114,11 +124,16 @@ describe('GET /users', () => {
     const res = await fetch('http://localhost/users?cursor=def-456&take=2')
     const users = await res.json()
 
-    expect(users).toHaveLength(2)
-    expect(users[0]).toHaveProperty('id', 'ghi-789')
-    expect(users[0]).toHaveProperty('firstName', 'Joseph')
-    expect(users[1]).toHaveProperty('id', 'xyz-321')
-    expect(users[1]).toHaveProperty('firstName', 'Eva')
+    expect(users).toEqual([
+      {
+        id: 'ghi-789',
+        firstName: 'Joseph',
+      },
+      {
+        id: 'xyz-321',
+        firstName: 'Eva',
+      },
+    ])
   })
 })
 
@@ -138,8 +153,10 @@ describe('GET /users/:id', () => {
     const user = await res.json()
 
     expect(res.status).toEqual(200)
-    expect(user).toHaveProperty('id', 'def-456')
-    expect(user).toHaveProperty('firstName', 'Kate')
+    expect(user).toEqual({
+      id: 'def-456',
+      firstName: 'Kate',
+    })
   })
 
   it('returns a 404 response when getting a non-existing entity', async () => {
@@ -177,8 +194,10 @@ describe('POST /users', () => {
     const user = await res.json()
 
     expect(res.status).toEqual(201)
-    expect(user).toHaveProperty('id', 'abc-123')
-    expect(user).toHaveProperty('firstName', 'Joseph')
+    expect(user).toEqual({
+      id: 'abc-123',
+      firstName: 'Joseph',
+    })
   })
 
   it('returns a 409 response when creating a user with the same id', async () => {
@@ -227,8 +246,10 @@ describe('PUT /users/:id', () => {
     const user = await res.json()
 
     expect(res.status).toEqual(200)
-    expect(user).toHaveProperty('id', 'abc-123')
-    expect(user).toHaveProperty('firstName', 'Joseph')
+    expect(user).toEqual({
+      id: 'abc-123',
+      firstName: 'Joseph',
+    })
   })
 
   it('returns a 404 response when updating a non-existing entity', async () => {
@@ -300,15 +321,20 @@ describe('DELETE /users/:id', () => {
     })
     const user = await res.json()
     expect(res.status).toEqual(200)
-    expect(user).toHaveProperty('id', 'def-456')
-    expect(user).toHaveProperty('firstName', 'Kate')
+    expect(user).toEqual({
+      id: 'def-456',
+      firstName: 'Kate',
+    })
 
     const allUsers = await fetch('http://localhost/users').then((res) =>
       res.json(),
     )
-    expect(allUsers).toHaveLength(1)
-    expect(allUsers[0]).toHaveProperty('id', 'abc-123')
-    expect(allUsers[0]).toHaveProperty('firstName', 'John')
+    expect(allUsers).toEqual([
+      {
+        id: 'abc-123',
+        firstName: 'John',
+      },
+    ])
   })
 
   it('returns a 404 response when deleting a non-existing entity', async () => {

--- a/test/utils/cleanEntity.test.ts
+++ b/test/utils/cleanEntity.test.ts
@@ -1,0 +1,24 @@
+import { factory, primaryKey } from '../../src'
+import { removeInternalProperties } from '../../src/utils/removeInternalProperties'
+
+const db = factory({
+  user: {
+    id: primaryKey(String),
+    firstName: String,
+  },
+})
+
+beforeAll(() => {
+  db.user.create({
+    id: 'abc-123',
+    firstName: 'John',
+  })
+})
+
+it('removes internal properties from an entity', () => {
+  const user = db.user.findFirst({ which: { id: { equals: 'abc-123' } } })
+  expect(removeInternalProperties(user)).toEqual({
+    id: 'abc-123',
+    firstName: 'John',
+  })
+})


### PR DESCRIPTION
## GitHub

- Closes #41 

## Changes

The entity(-ies) JSON returned from the generated handlers (`.toHandlers`) now does not have any internal properties (`__primaryKey`, `__type`, etc.). 

## Motivation

When using the handlers, developers will work and assert the returned response data in a strict way. Internal properties must not leak to the public response. 