### PR TITLE
Database: Supports events

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "date-fns": "^2.20.0",
     "graphql": "^15.5.0",
     "pluralize": "^8.0.0",
+    "strict-event-emitter": "^0.2.0",
     "uuid": "^8.3.1"
   },
   "optionalDependencies": {


### PR DESCRIPTION
## Changes

- Adds a new public property "events" to the Database class.
- Supports three main events:
  - create: when a new entity is created;
  - update: when an existing entity is updated;
  - delete: when an existing entity is deleted.

## Motivation

- Pre-requisite for #49, #54 

By adding events to the Database, it becomes possible to listen to when they occur:

```js
db.events.on('create', (modelName, prevEntity, nextEntity) => {
  console.log('created a new entity', modelName)
})
```

Persistency and synchronization would use database events to know when to apply them to other database instances (i.e. in other clients, or to the server instance). 