### PR TITLE
feat: remove all internals from API model

### DIFF
--- a/src/db/Database.ts
+++ b/src/db/Database.ts
@@ -1,14 +1,10 @@
 import md5 from 'md5'
 import { StrictEventEmitter } from 'strict-event-emitter'
-import {
-  InternalEntityInstance,
-  ModelDictionary,
-  PrimaryKeyType,
-} from '../glossary'
+import { InternalEntity, ModelDictionary, PrimaryKeyType } from '../glossary'
 
 type Models<Dictionary extends ModelDictionary> = Record<
   string,
-  Map<string, InternalEntityInstance<Dictionary, any>>
+  Map<string, InternalEntity<Dictionary, any>>
 >
 
 export type DatabaseMethodToEventFn<Method extends (...args: any[]) => any> = (
@@ -33,10 +29,7 @@ export class Database<Dictionary extends ModelDictionary> {
     this.events = new StrictEventEmitter()
     this.models = Object.keys(dictionary).reduce<Models<Dictionary>>(
       (acc, modelName) => {
-        acc[modelName] = new Map<
-          string,
-          InternalEntityInstance<Dictionary, string>
-        >()
+        acc[modelName] = new Map<string, InternalEntity<Dictionary, string>>()
         return acc
       },
       {},
@@ -64,7 +57,7 @@ export class Database<Dictionary extends ModelDictionary> {
 
   create<ModelName extends string>(
     modelName: ModelName,
-    entity: InternalEntityInstance<Dictionary, any>,
+    entity: InternalEntity<Dictionary, any>,
     customPrimaryKey?: PrimaryKeyType,
   ) {
     const primaryKey =
@@ -77,8 +70,8 @@ export class Database<Dictionary extends ModelDictionary> {
 
   update<ModelName extends string>(
     modelName: ModelName,
-    prevEntity: InternalEntityInstance<Dictionary, any>,
-    nextEntity: InternalEntityInstance<Dictionary, any>,
+    prevEntity: InternalEntity<Dictionary, any>,
+    nextEntity: InternalEntity<Dictionary, any>,
   ) {
     const prevPrimaryKey = prevEntity[prevEntity.__primaryKey]
     const nextPrimaryKey = nextEntity[prevEntity.__primaryKey]
@@ -112,7 +105,7 @@ export class Database<Dictionary extends ModelDictionary> {
 
   listEntities<ModelName extends string>(
     modelName: ModelName,
-  ): InternalEntityInstance<Dictionary, ModelName>[] {
+  ): InternalEntity<Dictionary, ModelName>[] {
     return Array.from(this.getModel(modelName).values())
   }
 }

--- a/src/db/Database.ts
+++ b/src/db/Database.ts
@@ -1,6 +1,11 @@
 import md5 from 'md5'
 import { StrictEventEmitter } from 'strict-event-emitter'
-import { InternalEntity, ModelDictionary, PrimaryKeyType } from '../glossary'
+import {
+  InternalEntity,
+  InternalEntityProperty,
+  ModelDictionary,
+  PrimaryKeyType,
+} from '../glossary'
 
 type Models<Dictionary extends ModelDictionary> = Record<
   string,
@@ -61,7 +66,8 @@ export class Database<Dictionary extends ModelDictionary> {
     customPrimaryKey?: PrimaryKeyType,
   ) {
     const primaryKey =
-      customPrimaryKey || (entity[entity.__primaryKey] as string)
+      customPrimaryKey ||
+      (entity[entity[InternalEntityProperty.primaryKey]] as string)
 
     this.events.emit('create', this.id, modelName, entity, customPrimaryKey)
 
@@ -73,8 +79,10 @@ export class Database<Dictionary extends ModelDictionary> {
     prevEntity: InternalEntity<Dictionary, any>,
     nextEntity: InternalEntity<Dictionary, any>,
   ) {
-    const prevPrimaryKey = prevEntity[prevEntity.__primaryKey]
-    const nextPrimaryKey = nextEntity[prevEntity.__primaryKey]
+    const prevPrimaryKey =
+      prevEntity[prevEntity[InternalEntityProperty.primaryKey]]
+    const nextPrimaryKey =
+      nextEntity[prevEntity[InternalEntityProperty.primaryKey]]
 
     if (nextPrimaryKey !== prevPrimaryKey) {
       this.delete(modelName, prevPrimaryKey as string)

--- a/src/db/Database.ts
+++ b/src/db/Database.ts
@@ -1,10 +1,14 @@
 import md5 from 'md5'
 import { StrictEventEmitter } from 'strict-event-emitter'
-import { EntityInstance, ModelDictionary, PrimaryKeyType } from '../glossary'
+import {
+  InternalEntityInstance,
+  ModelDictionary,
+  PrimaryKeyType,
+} from '../glossary'
 
 type Models<Dictionary extends ModelDictionary> = Record<
   string,
-  Map<string, EntityInstance<Dictionary, any>>
+  Map<string, InternalEntityInstance<Dictionary, any>>
 >
 
 export type DatabaseMethodToEventFn<Method extends (...args: any[]) => any> = (
@@ -29,7 +33,10 @@ export class Database<Dictionary extends ModelDictionary> {
     this.events = new StrictEventEmitter()
     this.models = Object.keys(dictionary).reduce<Models<Dictionary>>(
       (acc, modelName) => {
-        acc[modelName] = new Map<string, EntityInstance<Dictionary, string>>()
+        acc[modelName] = new Map<
+          string,
+          InternalEntityInstance<Dictionary, string>
+        >()
         return acc
       },
       {},
@@ -57,7 +64,7 @@ export class Database<Dictionary extends ModelDictionary> {
 
   create<ModelName extends string>(
     modelName: ModelName,
-    entity: EntityInstance<Dictionary, any>,
+    entity: InternalEntityInstance<Dictionary, any>,
     customPrimaryKey?: PrimaryKeyType,
   ) {
     const primaryKey =
@@ -70,8 +77,8 @@ export class Database<Dictionary extends ModelDictionary> {
 
   update<ModelName extends string>(
     modelName: ModelName,
-    prevEntity: EntityInstance<Dictionary, ModelName>,
-    nextEntity: EntityInstance<Dictionary, ModelName>,
+    prevEntity: InternalEntityInstance<Dictionary, any>,
+    nextEntity: InternalEntityInstance<Dictionary, any>,
   ) {
     const prevPrimaryKey = prevEntity[prevEntity.__primaryKey]
     const nextPrimaryKey = nextEntity[prevEntity.__primaryKey]
@@ -105,7 +112,7 @@ export class Database<Dictionary extends ModelDictionary> {
 
   listEntities<ModelName extends string>(
     modelName: ModelName,
-  ): EntityInstance<Dictionary, ModelName>[] {
+  ): InternalEntityInstance<Dictionary, ModelName>[] {
     return Array.from(this.getModel(modelName).values())
   }
 }

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,5 +1,5 @@
 import {
-  InternalEntityInstance,
+  InternalEntity,
   FactoryAPI,
   ModelAPI,
   ModelDefinition,
@@ -163,7 +163,7 @@ function createModelApi<
     },
     updateMany({ strict, ...query }) {
       const records = executeQuery(modelName, primaryKey, query, db)
-      const updatedRecords: InternalEntityInstance<any, any>[] = []
+      const updatedRecords: InternalEntity<any, any>[] = []
 
       if (records.length === 0) {
         invariant(

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -4,6 +4,7 @@ import {
   ModelAPI,
   ModelDefinition,
   ModelDictionary,
+  InternalEntityProperty,
 } from './glossary'
 import { first } from './utils/first'
 import { executeQuery } from './query/executeQuery'
@@ -70,7 +71,9 @@ function createModelApi<
         db,
       )
 
-      const entityId = entity[entity.__primaryKey] as string
+      const entityId = entity[
+        entity[InternalEntityProperty.primaryKey]
+      ] as string
 
       invariant(
         !entityId,
@@ -81,7 +84,9 @@ function createModelApi<
       // Prevent creation of multiple entities with the same primary key value.
       invariant(
         db.has(modelName, entityId),
-        `Failed to create a "${modelName}" entity: an entity with the same primary key "${entityId}" ("${entity.__primaryKey}") already exists.`,
+        `Failed to create a "${modelName}" entity: an entity with the same primary key "${entityId}" ("${
+          entity[InternalEntityProperty.primaryKey]
+        }") already exists.`,
         new OperationError(OperationErrorType.DuplicatePrimaryKey),
       )
 
@@ -145,13 +150,16 @@ function createModelApi<
       const nextRecord = updateEntity(prevRecord, query.data)
 
       if (
-        nextRecord[prevRecord.__primaryKey] !==
-        prevRecord[prevRecord.__primaryKey]
+        nextRecord[prevRecord[InternalEntityProperty.primaryKey]] !==
+        prevRecord[prevRecord[InternalEntityProperty.primaryKey]]
       ) {
         invariant(
-          db.has(modelName, nextRecord[prevRecord.__primaryKey]),
+          db.has(
+            modelName,
+            nextRecord[prevRecord[InternalEntityProperty.primaryKey]],
+          ),
           `Failed to execute "update" on the "${modelName}" model: the entity with a primary key "${
-            nextRecord[prevRecord.__primaryKey]
+            nextRecord[prevRecord[InternalEntityProperty.primaryKey]]
           }" ("${primaryKey}") already exists.`,
           new OperationError(OperationErrorType.DuplicatePrimaryKey),
         )
@@ -181,11 +189,14 @@ function createModelApi<
         const nextRecord = updateEntity(prevRecord, query.data)
 
         if (
-          nextRecord[prevRecord.__primaryKey] !==
-          prevRecord[prevRecord.__primaryKey]
+          nextRecord[prevRecord[InternalEntityProperty.primaryKey]] !==
+          prevRecord[prevRecord[InternalEntityProperty.primaryKey]]
         ) {
           invariant(
-            db.has(modelName, nextRecord[prevRecord.__primaryKey]),
+            db.has(
+              modelName,
+              nextRecord[prevRecord[InternalEntityProperty.primaryKey]],
+            ),
             `Failed to execute "updateMany" on the "${modelName}" model: no entities found matching the query "${JSON.stringify(
               query.where,
             )}".`,
@@ -215,7 +226,10 @@ function createModelApi<
         return null
       }
 
-      db.delete(modelName, record[record.__primaryKey] as string)
+      db.delete(
+        modelName,
+        record[record[InternalEntityProperty.primaryKey]] as string,
+      )
       return removeInternalProperties(record)
     },
     deleteMany({ strict, ...query }) {
@@ -234,7 +248,10 @@ function createModelApi<
       }
 
       records.forEach((record) => {
-        db.delete(modelName, record[record.__primaryKey] as string)
+        db.delete(
+          modelName,
+          record[record[InternalEntityProperty.primaryKey]] as string,
+        )
       })
 
       return records.map(removeInternalProperties)

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -83,15 +83,15 @@ export interface InternalEntityProperties<ModelName extends KeyType> {
   readonly [InternalEntityProperty.primaryKey]: PrimaryKeyType
 }
 
-export type EntityInstance<
+export type Entity<
   Dictionary extends Record<string, any>,
   ModelName extends keyof Dictionary
 > = Value<Dictionary[ModelName], Dictionary>
 
-export type InternalEntityInstance<
+export type InternalEntity<
   Dictionary extends Record<string, any>,
   ModelName extends keyof Dictionary
-> = InternalEntityProperties<ModelName> & EntityInstance<Dictionary, ModelName>
+> = InternalEntityProperties<ModelName> & Entity<Dictionary, ModelName>
 
 export type ModelDictionary = Limit<Record<string, Record<string, any>>>
 
@@ -119,7 +119,7 @@ export interface ModelAPI<
    */
   create(
     initialValues?: Partial<Value<Dictionary[ModelName], Dictionary>>,
-  ): EntityInstance<Dictionary, ModelName>
+  ): Entity<Dictionary, ModelName>
   /**
    * Return the total number of entities.
    */
@@ -129,18 +129,18 @@ export interface ModelAPI<
    */
   findFirst(
     query: QuerySelector<Value<Dictionary[ModelName], Dictionary>>,
-  ): EntityInstance<Dictionary, ModelName> | null
+  ): Entity<Dictionary, ModelName> | null
   /**
    * Find multiple entities.
    */
   findMany(
     query: WeakQuerySelector<Value<Dictionary[ModelName], Dictionary>> &
       BulkQueryOptions,
-  ): EntityInstance<Dictionary, ModelName>[]
+  ): Entity<Dictionary, ModelName>[]
   /**
    * Return all entities of the current model.
    */
-  getAll(): EntityInstance<Dictionary, ModelName>[]
+  getAll(): Entity<Dictionary, ModelName>[]
   /**
    * Update a single entity with the next data.
    */
@@ -148,7 +148,7 @@ export interface ModelAPI<
     query: QuerySelector<Value<Dictionary[ModelName], Dictionary>> & {
       data: Partial<UpdateManyValue<Dictionary[ModelName], Dictionary>>
     },
-  ): EntityInstance<Dictionary, ModelName> | null
+  ): Entity<Dictionary, ModelName> | null
   /**
    * Update many entities with the next data.
    */
@@ -156,19 +156,19 @@ export interface ModelAPI<
     query: QuerySelector<Value<Dictionary[ModelName], Dictionary>> & {
       data: Partial<UpdateManyValue<Dictionary[ModelName], Dictionary>>
     },
-  ): EntityInstance<Dictionary, ModelName>[] | null
+  ): Entity<Dictionary, ModelName>[] | null
   /**
    * Delete a single entity.
    */
   delete(
     query: QuerySelector<Value<Dictionary[ModelName], Dictionary>>,
-  ): EntityInstance<Dictionary, ModelName> | null
+  ): Entity<Dictionary, ModelName> | null
   /**
    * Delete multiple entities.
    */
   deleteMany(
     query: QuerySelector<Value<Dictionary[ModelName], Dictionary>>,
-  ): EntityInstance<Dictionary, ModelName>[] | null
+  ): Entity<Dictionary, ModelName>[] | null
   /**
    * Generate request handlers of the given type based on the model.
    */
@@ -200,9 +200,9 @@ export type Value<
   Parent extends Record<string, any>
 > = {
   [K in keyof T]: T[K] extends OneOf<any>
-    ? EntityInstance<Parent, T[K]['modelName']>
+    ? Entity<Parent, T[K]['modelName']>
     : T[K] extends ManyOf<any>
-    ? EntityInstance<Parent, T[K]['modelName']>[]
+    ? Entity<Parent, T[K]['modelName']>[]
     : T[K] extends PrimaryKeyDeclaration
     ? ReturnType<T[K]['getValue']>
     : ReturnType<T[K]>

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -36,6 +36,7 @@ export interface Relation {
   kind: RelationKind
   modelName: string
   unique: boolean
+  primaryKey: PrimaryKeyType
 }
 
 /**
@@ -79,8 +80,12 @@ export interface InternalEntityProperties<ModelName extends KeyType> {
 export type EntityInstance<
   Dictionary extends Record<string, any>,
   ModelName extends keyof Dictionary
-> = InternalEntityProperties<ModelName> &
-  Value<Dictionary[ModelName], Dictionary>
+> = Value<Dictionary[ModelName], Dictionary>
+
+export type InternalEntityInstance<
+  Dictionary extends Record<string, any>,
+  ModelName extends keyof Dictionary
+> = InternalEntityProperties<ModelName> & EntityInstance<Dictionary, ModelName>
 
 export type ModelDictionary = Limit<Record<string, Record<string, any>>>
 
@@ -118,7 +123,7 @@ export interface ModelAPI<
    */
   findFirst(
     query: QuerySelector<Value<Dictionary[ModelName], Dictionary>>,
-  ): EntityInstance<Dictionary, ModelName>
+  ): EntityInstance<Dictionary, ModelName> | null
   /**
    * Find multiple entities.
    */
@@ -145,7 +150,7 @@ export interface ModelAPI<
     query: QuerySelector<Value<Dictionary[ModelName], Dictionary>> & {
       data: Partial<UpdateManyValue<Dictionary[ModelName], Dictionary>>
     },
-  ): Value<Dictionary[ModelName], Dictionary>[] | null
+  ): EntityInstance<Dictionary, ModelName>[] | null
   /**
    * Delete a single entity.
    */

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -9,6 +9,12 @@ export type PrimaryKeyType = string
 export type BaseTypes = string | number | boolean | Date
 export type KeyType = string | number | symbol
 
+export enum InternalEntityProperty {
+  type = '__type',
+  nodeId = '__nodeId',
+  primaryKey = '__primaryKey',
+}
+
 export interface PrimaryKeyDeclaration {
   isPrimaryKey: boolean
   getValue(): PrimaryKeyType
@@ -46,7 +52,7 @@ export interface Relation {
 export type RelationRef<
   ModelName extends string
 > = InternalEntityProperties<ModelName> & {
-  __nodeId: PrimaryKeyType
+  [InternalEntityProperty.nodeId]: PrimaryKeyType
 }
 
 export interface RelationOptions {
@@ -73,8 +79,8 @@ export type FactoryAPI<Dictionary extends Record<string, any>> = {
 }
 
 export interface InternalEntityProperties<ModelName extends KeyType> {
-  readonly __type: ModelName
-  readonly __primaryKey: PrimaryKeyType
+  readonly [InternalEntityProperty.type]: ModelName
+  readonly [InternalEntityProperty.primaryKey]: PrimaryKeyType
 }
 
 export type EntityInstance<

--- a/src/model/createModel.ts
+++ b/src/model/createModel.ts
@@ -3,6 +3,7 @@ import { Database } from '../db/Database'
 import {
   InternalEntity,
   InternalEntityProperties,
+  InternalEntityProperty,
   ModelDefinition,
   ModelDictionary,
   Value,
@@ -33,8 +34,8 @@ export function createModel<
   )
 
   const internalProperties: InternalEntityProperties<ModelName> = {
-    __type: modelName,
-    __primaryKey: primaryKey,
+    [InternalEntityProperty.type]: modelName,
+    [InternalEntityProperty.primaryKey]: primaryKey,
   }
 
   const resolvedProperties = properties.reduce<Record<string, any>>(
@@ -73,22 +74,6 @@ export function createModel<
     },
     {},
   )
-
-  // const two = Object.entries(relations).reduce(
-  //   (entity, [property, relation]) => {
-  //     const entityRef = initialValues[property]!
-
-  //     invariant(
-  //       entityRef,
-  //       `Failed to set "${modelName}.${property}" relational property: expected an initial value, but got: ${exactVaentityReflue}`,
-  //     )
-
-  //     entityRef
-
-  //     return entity
-  //   },
-  //   foo,
-  // )
 
   const entity = Object.assign({}, resolvedProperties, internalProperties)
   defineRelationalProperties(entity, initialValues, relations, db)

--- a/src/model/createModel.ts
+++ b/src/model/createModel.ts
@@ -1,7 +1,7 @@
 import { debug } from 'debug'
 import { Database } from '../db/Database'
 import {
-  EntityInstance,
+  InternalEntityInstance,
   InternalEntityProperties,
   ModelDefinition,
   ModelDictionary,
@@ -21,7 +21,7 @@ export function createModel<
   parsedModel: ParsedModelDefinition,
   initialValues: Partial<Value<Dictionary[ModelName], Dictionary>>,
   db: Database<Dictionary>,
-): EntityInstance<any, any> {
+): InternalEntityInstance<any, any> {
   const { primaryKey, properties, relations } = parsedModel
 
   log(

--- a/src/model/createModel.ts
+++ b/src/model/createModel.ts
@@ -1,7 +1,7 @@
 import { debug } from 'debug'
 import { Database } from '../db/Database'
 import {
-  InternalEntityInstance,
+  InternalEntity,
   InternalEntityProperties,
   ModelDefinition,
   ModelDictionary,
@@ -21,7 +21,7 @@ export function createModel<
   parsedModel: ParsedModelDefinition,
   initialValues: Partial<Value<Dictionary[ModelName], Dictionary>>,
   db: Database<Dictionary>,
-): InternalEntityInstance<any, any> {
+): InternalEntity<any, any> {
   const { primaryKey, properties, relations } = parsedModel
 
   log(

--- a/src/model/defineRelationalProperties.ts
+++ b/src/model/defineRelationalProperties.ts
@@ -42,11 +42,6 @@ export function defineRelationalProperties(
       if (relation.unique) {
         log(`verifying that the "${property}" relation is unique...`)
 
-        /**
-         * @fixme Is it safe to assume the first reference?
-         */
-        const firstRef = entityRefs[0]
-
         // Trying to look up an entity of the same type
         // that references the same relational entity.
         const existingEntities = executeQuery(

--- a/src/model/defineRelationalProperties.ts
+++ b/src/model/defineRelationalProperties.ts
@@ -13,6 +13,12 @@ import { first } from '../utils/first'
 
 const log = debug('defineRelationalProperties')
 
+type RelationalPropertyDescriptorMap = {
+  [property: string]: Omit<PropertyDescriptor, 'get'> & {
+    get(): InternalEntity<any, any> | InternalEntity<any, any>[]
+  }
+}
+
 export function defineRelationalProperties(
   entity: InternalEntity<any, any>,
   initialValues: Partial<Value<any, ModelDictionary>>,
@@ -21,97 +27,97 @@ export function defineRelationalProperties(
 ): void {
   log('setting relations', relations, entity)
 
-  const properties = Object.entries(relations).reduce<
-    Record<
-      string,
-      {
-        get(): InternalEntity<any, any> | InternalEntity<any, any>[]
-        enumerable: boolean
-      }
-    >
-  >((properties, [property, relation]) => {
-    log(`defining relational property "${entity.__type}.${property}"`, relation)
-    // Take the relational entity reference from the initial values.
-    const entityRefs: Entity<any, any>[] = [].concat(initialValues[property])
+  const properties = Object.entries(
+    relations,
+  ).reduce<RelationalPropertyDescriptorMap>(
+    (properties, [property, relation]) => {
+      log(
+        `defining relational property "${entity.__type}.${property}"`,
+        relation,
+      )
+      // Take the relational entity reference from the initial values.
+      const entityRefs: Entity<any, any>[] = [].concat(initialValues[property])
 
-    if (relation.unique) {
-      log(`verifying that the "${property}" relation is unique...`)
+      if (relation.unique) {
+        log(`verifying that the "${property}" relation is unique...`)
 
-      /**
-       * @fixme Is it safe to assume the first reference?
-       */
-      const firstRef = entityRefs[0]
+        /**
+         * @fixme Is it safe to assume the first reference?
+         */
+        const firstRef = entityRefs[0]
 
-      // Trying to look up an entity of the same type
-      // that references the same relational entity.
-      const existingEntities = executeQuery(
-        entity.__type,
-        entity.__primaryKey,
-        {
-          where: {
-            [property]: {
-              [relation.primaryKey]: {
-                in: entityRefs.map(
-                  (entityRef) => entityRef[entity.__primaryKey],
-                ),
+        // Trying to look up an entity of the same type
+        // that references the same relational entity.
+        const existingEntities = executeQuery(
+          entity.__type,
+          entity.__primaryKey,
+          {
+            where: {
+              [property]: {
+                [relation.primaryKey]: {
+                  in: entityRefs.map(
+                    (entityRef) => entityRef[entity.__primaryKey],
+                  ),
+                },
               },
             },
           },
-        },
-        db,
-      )
-
-      log(
-        `existing entities that reference the same "${property}"`,
-        existingEntities,
-      )
-
-      if (existingEntities.length > 0) {
-        log(`found a non-unique relational entity!`)
-
-        throw new Error(
-          `Failed to create a unique "${relation.modelName}" relation for "${
-            entity.__type
-          }.${property}" (${
-            entity[entity.__primaryKey]
-          }): the provided entity is already used.`,
+          db,
         )
+
+        log(
+          `existing entities that reference the same "${property}"`,
+          existingEntities,
+        )
+
+        if (existingEntities.length > 0) {
+          log(`found a non-unique relational entity!`)
+
+          throw new Error(
+            `Failed to create a unique "${relation.modelName}" relation for "${
+              entity.__type
+            }.${property}" (${
+              entity[entity.__primaryKey]
+            }): the provided entity is already used.`,
+          )
+        }
       }
-    }
 
-    properties[property] = {
-      enumerable: true,
-      get() {
-        log(`get "${property}"`, relation)
+      properties[property] = {
+        enumerable: true,
+        get() {
+          log(`get "${property}"`, relation)
 
-        const refValue = entityRefs.reduce<InternalEntity<any, any>[]>(
-          (list, entityRef) => {
-            return list.concat(
-              executeQuery(
-                relation.modelName,
-                relation.primaryKey,
-                {
-                  where: {
-                    [relation.primaryKey]: {
-                      equals: entityRef[relation.primaryKey],
+          const refValue = entityRefs.reduce<InternalEntity<any, any>[]>(
+            (list, entityRef) => {
+              return list.concat(
+                executeQuery(
+                  relation.modelName,
+                  relation.primaryKey,
+                  {
+                    where: {
+                      [relation.primaryKey]: {
+                        equals: entityRef[relation.primaryKey],
+                      },
                     },
                   },
-                },
-                db,
-              ),
-            )
-          },
-          [],
-        )
-        log(`resolved "${relation.kind}" "${property}" to`, refValue)
+                  db,
+                ),
+              )
+            },
+            [],
+          )
+          log(`resolved "${relation.kind}" "${property}" to`, refValue)
 
-        return relation.kind === RelationKind.OneOf
-          ? first(refValue)!
-          : refValue
-      },
-    }
+          return relation.kind === RelationKind.OneOf
+            ? first(refValue)!
+            : refValue
+        },
+      }
 
-    return properties
-  }, {})
+      return properties
+    },
+    {},
+  )
   Object.defineProperties(entity, properties)
 }

--- a/src/model/defineRelationalProperties.ts
+++ b/src/model/defineRelationalProperties.ts
@@ -1,8 +1,8 @@
 import { debug } from 'debug'
 import { Database } from '../db/Database'
 import {
-  InternalEntityInstance,
-  EntityInstance,
+  Entity,
+  InternalEntity,
   ModelDictionary,
   Relation,
   RelationKind,
@@ -14,7 +14,7 @@ import { first } from '../utils/first'
 const log = debug('defineRelationalProperties')
 
 export function defineRelationalProperties(
-  entity: InternalEntityInstance<any, any>,
+  entity: InternalEntity<any, any>,
   initialValues: Partial<Value<any, ModelDictionary>>,
   relations: Record<string, Relation>,
   db: Database<any>,
@@ -25,18 +25,14 @@ export function defineRelationalProperties(
     Record<
       string,
       {
-        get():
-          | InternalEntityInstance<any, any>
-          | InternalEntityInstance<any, any>[]
+        get(): InternalEntity<any, any> | InternalEntity<any, any>[]
         enumerable: boolean
       }
     >
   >((properties, [property, relation]) => {
     log(`defining relational property "${entity.__type}.${property}"`, relation)
     // Take the relational entity reference from the initial values.
-    const entityRefs: EntityInstance<any, any>[] = [].concat(
-      initialValues[property],
-    )
+    const entityRefs: Entity<any, any>[] = [].concat(initialValues[property])
 
     if (relation.unique) {
       log(`verifying that the "${property}" relation is unique...`)
@@ -88,7 +84,7 @@ export function defineRelationalProperties(
       get() {
         log(`get "${property}"`, relation)
 
-        const refValue = entityRefs.reduce<InternalEntityInstance<any, any>[]>(
+        const refValue = entityRefs.reduce<InternalEntity<any, any>[]>(
           (list, entityRef) => {
             return list.concat(
               executeQuery(

--- a/src/model/defineRelationalProperties.ts
+++ b/src/model/defineRelationalProperties.ts
@@ -3,6 +3,7 @@ import { Database } from '../db/Database'
 import {
   Entity,
   InternalEntity,
+  InternalEntityProperty,
   ModelDictionary,
   Relation,
   RelationKind,
@@ -49,14 +50,15 @@ export function defineRelationalProperties(
         // Trying to look up an entity of the same type
         // that references the same relational entity.
         const existingEntities = executeQuery(
-          entity.__type,
-          entity.__primaryKey,
+          entity[InternalEntityProperty.type],
+          entity[InternalEntityProperty.primaryKey],
           {
             where: {
               [property]: {
                 [relation.primaryKey]: {
                   in: entityRefs.map(
-                    (entityRef) => entityRef[entity.__primaryKey],
+                    (entityRef) =>
+                      entityRef[entity[InternalEntityProperty.primaryKey]],
                   ),
                 },
               },
@@ -77,7 +79,7 @@ export function defineRelationalProperties(
             `Failed to create a unique "${relation.modelName}" relation for "${
               entity.__type
             }.${property}" (${
-              entity[entity.__primaryKey]
+              entity[entity[InternalEntityProperty.primaryKey]]
             }): the provided entity is already used.`,
           )
         }

--- a/src/model/generateRestHandlers.ts
+++ b/src/model/generateRestHandlers.ts
@@ -8,7 +8,6 @@ import {
 } from '../glossary'
 import { GetQueryFor } from '../query/queryTypes'
 import { OperationErrorType, OperationError } from '../errors/OperationError'
-import { removeInternalProperties } from '../utils/removeInternalProperties'
 
 interface WeakQuerySelectorWhere<KeyType extends PrimaryKeyType> {
   [key: string]: Partial<GetQueryFor<KeyType>>
@@ -93,7 +92,7 @@ export function generateRestHandlers<
 
         const records = model.findMany(options)
 
-        return res(ctx.json(records.map(removeInternalProperties)))
+        return res(ctx.json(records))
       }),
     ),
     rest.get(
@@ -113,17 +112,14 @@ export function generateRestHandlers<
           where: where as any,
         })
 
-        return res(ctx.json(removeInternalProperties(entity)))
+        return res(ctx.json(entity))
       }),
     ),
     rest.post(
       buildUrl(modelPath),
       withErrors<EntityInstance<Dictionary, ModelName>>((req, res, ctx) => {
         const createdEntity = model.create(req.body)
-        return res(
-          ctx.status(201),
-          ctx.json(removeInternalProperties(createdEntity)),
-        )
+        return res(ctx.status(201), ctx.json(createdEntity))
       }),
     ),
     rest.put(
@@ -144,7 +140,7 @@ export function generateRestHandlers<
           data: req.body,
         })!
 
-        return res(ctx.json(removeInternalProperties(updatedEntity)))
+        return res(ctx.json(updatedEntity))
       }),
     ),
     rest.delete(
@@ -164,7 +160,7 @@ export function generateRestHandlers<
           where: where as any,
         })!
 
-        return res(ctx.json(removeInternalProperties(deletedEntity)))
+        return res(ctx.json(deletedEntity))
       }),
     ),
   ]

--- a/src/model/generateRestHandlers.ts
+++ b/src/model/generateRestHandlers.ts
@@ -1,11 +1,6 @@
 import pluralize from 'pluralize'
 import { RestContext, RestRequest, ResponseResolver, rest } from 'msw'
-import {
-  EntityInstance,
-  ModelDictionary,
-  ModelAPI,
-  PrimaryKeyType,
-} from '../glossary'
+import { Entity, ModelDictionary, ModelAPI, PrimaryKeyType } from '../glossary'
 import { GetQueryFor } from '../query/queryTypes'
 import { OperationErrorType, OperationError } from '../errors/OperationError'
 
@@ -73,7 +68,7 @@ export function generateRestHandlers<
   return [
     rest.get(
       buildUrl(modelPath),
-      withErrors<EntityInstance<Dictionary, ModelName>>((req, res, ctx) => {
+      withErrors<Entity<Dictionary, ModelName>>((req, res, ctx) => {
         const cursor = req.url.searchParams.get('cursor')
         const rawSkip = req.url.searchParams.get('skip')
         const rawTake = req.url.searchParams.get('take')
@@ -97,71 +92,68 @@ export function generateRestHandlers<
     ),
     rest.get(
       buildUrl(`${modelPath}/:${primaryKey}`),
-      withErrors<
-        EntityInstance<Dictionary, ModelName>,
-        RequestParams<PrimaryKeyType>
-      >((req, res, ctx) => {
-        const id = req.params[primaryKey]
-        const where: WeakQuerySelectorWhere<typeof primaryKey> = {
-          [primaryKey]: {
-            equals: id,
-          },
-        }
-        const entity = model.findFirst({
-          strict: true,
-          where: where as any,
-        })
+      withErrors<Entity<Dictionary, ModelName>, RequestParams<PrimaryKeyType>>(
+        (req, res, ctx) => {
+          const id = req.params[primaryKey]
+          const where: WeakQuerySelectorWhere<typeof primaryKey> = {
+            [primaryKey]: {
+              equals: id,
+            },
+          }
+          const entity = model.findFirst({
+            strict: true,
+            where: where as any,
+          })
 
-        return res(ctx.json(entity))
-      }),
+          return res(ctx.json(entity))
+        },
+      ),
     ),
     rest.post(
       buildUrl(modelPath),
-      withErrors<EntityInstance<Dictionary, ModelName>>((req, res, ctx) => {
+      withErrors<Entity<Dictionary, ModelName>>((req, res, ctx) => {
         const createdEntity = model.create(req.body)
         return res(ctx.status(201), ctx.json(createdEntity))
       }),
     ),
     rest.put(
       buildUrl(`${modelPath}/:${primaryKey}`),
-      withErrors<
-        EntityInstance<Dictionary, ModelName>,
-        RequestParams<PrimaryKeyType>
-      >((req, res, ctx) => {
-        const id = req.params[primaryKey]
-        const where: WeakQuerySelectorWhere<typeof primaryKey> = {
-          [primaryKey]: {
-            equals: id,
-          },
-        }
-        const updatedEntity = model.update({
-          strict: true,
-          where: where as any,
-          data: req.body,
-        })!
+      withErrors<Entity<Dictionary, ModelName>, RequestParams<PrimaryKeyType>>(
+        (req, res, ctx) => {
+          const id = req.params[primaryKey]
+          const where: WeakQuerySelectorWhere<typeof primaryKey> = {
+            [primaryKey]: {
+              equals: id,
+            },
+          }
+          const updatedEntity = model.update({
+            strict: true,
+            where: where as any,
+            data: req.body,
+          })!
 
-        return res(ctx.json(updatedEntity))
-      }),
+          return res(ctx.json(updatedEntity))
+        },
+      ),
     ),
     rest.delete(
       buildUrl(`${modelPath}/:${primaryKey}`),
-      withErrors<
-        EntityInstance<Dictionary, ModelName>,
-        RequestParams<PrimaryKeyType>
-      >((req, res, ctx) => {
-        const id = req.params[primaryKey]
-        const where: WeakQuerySelectorWhere<typeof primaryKey> = {
-          [primaryKey]: {
-            equals: id,
-          },
-        }
-        const deletedEntity = model.delete({
-          strict: true,
-          where: where as any,
-        })!
+      withErrors<Entity<Dictionary, ModelName>, RequestParams<PrimaryKeyType>>(
+        (req, res, ctx) => {
+          const id = req.params[primaryKey]
+          const where: WeakQuerySelectorWhere<typeof primaryKey> = {
+            [primaryKey]: {
+              equals: id,
+            },
+          }
+          const deletedEntity = model.delete({
+            strict: true,
+            where: where as any,
+          })!
 
-        return res(ctx.json(deletedEntity))
-      }),
+          return res(ctx.json(deletedEntity))
+        },
+      ),
     ),
   ]
 }

--- a/src/model/parseModelDefinition.ts
+++ b/src/model/parseModelDefinition.ts
@@ -4,8 +4,10 @@ import {
   RelationKind,
   ModelDefinition,
   PrimaryKeyType,
+  ModelDictionary,
 } from '../glossary'
 import { invariant } from '../utils/invariant'
+import { findPrimaryKey } from '../utils/findPrimaryKey'
 
 const log = debug('parseModelDefinition')
 
@@ -15,7 +17,8 @@ export interface ParsedModelDefinition {
   relations: Record<string, Relation>
 }
 
-export function parseModelDefinition(
+export function parseModelDefinition<Dictionary extends ModelDictionary>(
+  dictionary: Dictionary,
   modelName: string,
   definition: ModelDefinition,
 ): ParsedModelDefinition {
@@ -42,10 +45,14 @@ export function parseModelDefinition(
         'kind' in valueGetter &&
         [RelationKind.OneOf, RelationKind.ManyOf].includes(valueGetter.kind)
       ) {
+        const relationPrimaryKey = findPrimaryKey(
+          dictionary[valueGetter.modelName],
+        )!
         result.relations[property] = {
           kind: valueGetter.kind,
           modelName: valueGetter.modelName,
           unique: valueGetter.unique,
+          primaryKey: relationPrimaryKey,
         }
 
         return result

--- a/src/model/updateEntity.ts
+++ b/src/model/updateEntity.ts
@@ -1,14 +1,14 @@
-import { InternalEntityInstance } from '../glossary'
+import { InternalEntity } from '../glossary'
 
 /**
  * Update given entity with the data, potentially evolving
  * it based on the existing values.
  */
 export function updateEntity(
-  entity: InternalEntityInstance<any, any>,
+  entity: InternalEntity<any, any>,
   data: any,
-): InternalEntityInstance<any, any> {
-  return Object.entries(data).reduce<InternalEntityInstance<any, any>>(
+): InternalEntity<any, any> {
+  return Object.entries(data).reduce<InternalEntity<any, any>>(
     (acc, [key, value]) => {
       // Ignore attempts to update entity with properties
       // that were not specified in the model definition.

--- a/src/model/updateEntity.ts
+++ b/src/model/updateEntity.ts
@@ -1,14 +1,14 @@
-import { EntityInstance } from '../glossary'
+import { InternalEntityInstance } from '../glossary'
 
 /**
  * Update given entity with the data, potentially evolving
  * it based on the existing values.
  */
 export function updateEntity(
-  entity: EntityInstance<any, any>,
+  entity: InternalEntityInstance<any, any>,
   data: any,
-): EntityInstance<any, any> {
-  return Object.entries(data).reduce<EntityInstance<any, any>>(
+): InternalEntityInstance<any, any> {
+  return Object.entries(data).reduce<InternalEntityInstance<any, any>>(
     (acc, [key, value]) => {
       // Ignore attempts to update entity with properties
       // that were not specified in the model definition.

--- a/src/query/executeQuery.ts
+++ b/src/query/executeQuery.ts
@@ -1,5 +1,5 @@
 import { debug } from 'debug'
-import { InternalEntity } from '../glossary'
+import { InternalEntity, InternalEntityProperty } from '../glossary'
 import { compileQuery } from './compileQuery'
 import {
   BulkQueryOptions,
@@ -21,7 +21,7 @@ function queryByPrimaryKey(
 
   return iteratorUtils.filter((id, value) => {
     return matchPrimaryKey({
-      [value.__primaryKey]: id,
+      [value[InternalEntityProperty.primaryKey]]: id,
     })
   }, records)
 }

--- a/src/query/executeQuery.ts
+++ b/src/query/executeQuery.ts
@@ -1,5 +1,5 @@
 import { debug } from 'debug'
-import { EntityInstance } from '../glossary'
+import { InternalEntityInstance } from '../glossary'
 import { compileQuery } from './compileQuery'
 import {
   BulkQueryOptions,
@@ -13,7 +13,7 @@ import { Database } from '../db/Database'
 const log = debug('executeQuery')
 
 function queryByPrimaryKey(
-  records: Map<string, EntityInstance<any, any>>,
+  records: Map<string, InternalEntityInstance<any, any>>,
   query: QuerySelector<any>,
 ) {
   log('querying by primary key')
@@ -35,7 +35,7 @@ export function executeQuery(
   primaryKey: string,
   query: WeakQuerySelector<any> & BulkQueryOptions,
   db: Database<any>,
-): EntityInstance<any, any>[] {
+): InternalEntityInstance<any, any>[] {
   log(`${JSON.stringify(query)} on "${modelName}"`)
   const records = db.getModel(modelName)
 

--- a/src/query/executeQuery.ts
+++ b/src/query/executeQuery.ts
@@ -1,5 +1,5 @@
 import { debug } from 'debug'
-import { InternalEntityInstance } from '../glossary'
+import { InternalEntity } from '../glossary'
 import { compileQuery } from './compileQuery'
 import {
   BulkQueryOptions,
@@ -13,7 +13,7 @@ import { Database } from '../db/Database'
 const log = debug('executeQuery')
 
 function queryByPrimaryKey(
-  records: Map<string, InternalEntityInstance<any, any>>,
+  records: Map<string, InternalEntity<any, any>>,
   query: QuerySelector<any>,
 ) {
   log('querying by primary key')
@@ -35,7 +35,7 @@ export function executeQuery(
   primaryKey: string,
   query: WeakQuerySelector<any> & BulkQueryOptions,
   db: Database<any>,
-): InternalEntityInstance<any, any>[] {
+): InternalEntity<any, any>[] {
   log(`${JSON.stringify(query)} on "${modelName}"`)
   const records = db.getModel(modelName)
 

--- a/src/query/paginateResults.ts
+++ b/src/query/paginateResults.ts
@@ -1,4 +1,4 @@
-import { InternalEntity } from '../glossary'
+import { InternalEntity, InternalEntityProperty } from '../glossary'
 import { BulkQueryOptions, WeakQuerySelector } from './queryTypes'
 
 function getEndIndex(start: number, end?: number) {
@@ -11,7 +11,7 @@ export function paginateResults(
 ): InternalEntity<any, any>[] {
   if (query.cursor) {
     const cursorIndex = data.findIndex((entity) => {
-      return entity[entity.__primaryKey] === query.cursor
+      return entity[entity[InternalEntityProperty.primaryKey]] === query.cursor
     })
 
     if (cursorIndex === -1) {

--- a/src/query/paginateResults.ts
+++ b/src/query/paginateResults.ts
@@ -1,4 +1,4 @@
-import { InternalEntityInstance } from '../glossary'
+import { InternalEntity } from '../glossary'
 import { BulkQueryOptions, WeakQuerySelector } from './queryTypes'
 
 function getEndIndex(start: number, end?: number) {
@@ -7,8 +7,8 @@ function getEndIndex(start: number, end?: number) {
 
 export function paginateResults(
   query: WeakQuerySelector<any> & BulkQueryOptions,
-  data: InternalEntityInstance<any, any>[],
-): InternalEntityInstance<any, any>[] {
+  data: InternalEntity<any, any>[],
+): InternalEntity<any, any>[] {
   if (query.cursor) {
     const cursorIndex = data.findIndex((entity) => {
       return entity[entity.__primaryKey] === query.cursor

--- a/src/query/paginateResults.ts
+++ b/src/query/paginateResults.ts
@@ -1,4 +1,4 @@
-import { EntityInstance } from '../glossary'
+import { InternalEntityInstance } from '../glossary'
 import { BulkQueryOptions, WeakQuerySelector } from './queryTypes'
 
 function getEndIndex(start: number, end?: number) {
@@ -7,8 +7,8 @@ function getEndIndex(start: number, end?: number) {
 
 export function paginateResults(
   query: WeakQuerySelector<any> & BulkQueryOptions,
-  data: EntityInstance<any, any>[],
-): EntityInstance<any, any>[] {
+  data: InternalEntityInstance<any, any>[],
+): InternalEntityInstance<any, any>[] {
   if (query.cursor) {
     const cursorIndex = data.findIndex((entity) => {
       return entity[entity.__primaryKey] === query.cursor

--- a/src/utils/first.ts
+++ b/src/utils/first.ts
@@ -3,6 +3,6 @@
  */
 export function first<ArrayType extends any[]>(
   arr: ArrayType,
-): ArrayType extends Array<infer ValueType> ? ValueType : never {
+): ArrayType extends Array<infer ValueType> ? ValueType | null : never {
   return arr != null && arr.length > 0 ? arr[0] : null
 }

--- a/src/utils/isInternalEntity.ts
+++ b/src/utils/isInternalEntity.ts
@@ -1,0 +1,13 @@
+import { InternalEntityInstance, InternalEntityProperty } from '../glossary'
+
+/**
+ * Determines if the given object is an internal entity.
+ */
+export function isInternalEntity(
+  value: Record<string, any>,
+): value is InternalEntityInstance<any, any> {
+  return (
+    InternalEntityProperty.type in value &&
+    InternalEntityProperty.primaryKey in value
+  )
+}

--- a/src/utils/isInternalEntity.ts
+++ b/src/utils/isInternalEntity.ts
@@ -1,11 +1,11 @@
-import { InternalEntityInstance, InternalEntityProperty } from '../glossary'
+import { InternalEntity, InternalEntityProperty } from '../glossary'
 
 /**
  * Determines if the given object is an internal entity.
  */
 export function isInternalEntity(
   value: Record<string, any>,
-): value is InternalEntityInstance<any, any> {
+): value is InternalEntity<any, any> {
   return (
     InternalEntityProperty.type in value &&
     InternalEntityProperty.primaryKey in value

--- a/src/utils/removeInternalProperties.ts
+++ b/src/utils/removeInternalProperties.ts
@@ -1,8 +1,4 @@
-import {
-  InternalEntityInstance,
-  InternalEntityProperty,
-  EntityInstance,
-} from '../glossary'
+import { InternalEntity, InternalEntityProperty, Entity } from '../glossary'
 import { isInternalEntity } from './isInternalEntity'
 
 /**
@@ -12,8 +8,8 @@ export function removeInternalProperties<
   Dictionary extends Record<string, any>,
   ModelName extends keyof Dictionary
 >(
-  entity: InternalEntityInstance<Dictionary, ModelName>,
-): EntityInstance<Dictionary, ModelName> {
+  entity: InternalEntity<Dictionary, ModelName>,
+): Entity<Dictionary, ModelName> {
   return (
     Object.entries(entity)
       // Remove internal entity properties.
@@ -25,27 +21,25 @@ export function removeInternalProperties<
           return [property, value]
         }
       })
-      .map<[string, EntityInstance<Dictionary, ModelName>]>(
-        ([property, value]) => {
-          // Remove internal properties of a "oneOf" relation.
-          if (typeof value === 'object' && isInternalEntity(value)) {
-            return [property, removeInternalProperties(value)]
-          }
+      .map<[string, Entity<Dictionary, ModelName>]>(([property, value]) => {
+        // Remove internal properties of a "oneOf" relation.
+        if (typeof value === 'object' && isInternalEntity(value)) {
+          return [property, removeInternalProperties(value)]
+        }
 
-          // Remove internal properties of a "manyOf" relation.
-          if (Array.isArray(value)) {
-            const publicEntity = value.map((relationalEntity: any) => {
-              return isInternalEntity(relationalEntity)
-                ? removeInternalProperties(relationalEntity)
-                : relationalEntity
-            })
+        // Remove internal properties of a "manyOf" relation.
+        if (Array.isArray(value)) {
+          const publicEntity = value.map((relationalEntity: any) => {
+            return isInternalEntity(relationalEntity)
+              ? removeInternalProperties(relationalEntity)
+              : relationalEntity
+          })
 
-            return [property, publicEntity]
-          }
+          return [property, publicEntity]
+        }
 
-          return [property, value]
-        },
-      )
+        return [property, value]
+      })
       .reduce<any>((entity, [property, value]) => {
         entity[property] = value
         return entity

--- a/src/utils/removeInternalProperties.ts
+++ b/src/utils/removeInternalProperties.ts
@@ -1,14 +1,32 @@
-import { EntityInstance, InternalEntityProperties } from '../glossary'
+import { InternalEntityInstance, EntityInstance } from '../glossary'
+
+function isInternalEntity(
+  value: any,
+): value is InternalEntityInstance<any, any> {
+  return typeof value === 'object' && '__type' in value
+}
 
 /**
  * Remove internal properties from the given entity.
  */
 export function removeInternalProperties<
-  Entity extends EntityInstance<any, any>
->(entity: Entity): Omit<Entity, keyof InternalEntityProperties<any>> {
+  Dictionary extends Record<string, any>,
+  ModelName extends keyof Dictionary
+>(
+  entity: InternalEntityInstance<Dictionary, ModelName>,
+): EntityInstance<Dictionary, ModelName> {
   return Object.entries(entity).reduce<any>((result, [key, value]) => {
     if (!key.startsWith('__')) {
-      result[key] = value
+      if (isInternalEntity(value)) {
+        result[key] = removeInternalProperties(value)
+      } else if (Array.isArray(value)) {
+        result[key] = value.reduce((acc: any[], reletionalEntity: any[]) => {
+          if (isInternalEntity(reletionalEntity)) {
+            acc.push(removeInternalProperties(reletionalEntity))
+          } else acc.push(reletionalEntity)
+          return acc
+        }, [])
+      } else result[key] = value
     }
 
     return result

--- a/test/db/events.test.ts
+++ b/test/db/events.test.ts
@@ -4,11 +4,14 @@ import { createModel } from '../../src/model/createModel'
 import { parseModelDefinition } from '../../src/model/parseModelDefinition'
 
 test('emits the "create" event when a new entity is created', (done) => {
-  const userDefinition = {
-    id: primaryKey(String),
+  const dictionary = {
+    user: {
+      id: primaryKey(String),
+    },
   }
+
   const db = new Database({
-    user: userDefinition,
+    user: dictionary.user,
   })
 
   db.events.on('create', (id, modelName, entity, primaryKey) => {
@@ -27,8 +30,8 @@ test('emits the "create" event when a new entity is created', (done) => {
     'user',
     createModel(
       'user',
-      userDefinition,
-      parseModelDefinition('user', userDefinition),
+      dictionary.user,
+      parseModelDefinition(dictionary, 'user', dictionary.user),
       {
         id: 'abc-123',
       },
@@ -38,12 +41,15 @@ test('emits the "create" event when a new entity is created', (done) => {
 })
 
 test('emits the "update" event when an existing entity is updated', (done) => {
-  const userDefinition = {
-    id: primaryKey(String),
-    firstName: String,
+  const dictionary = {
+    user: {
+      id: primaryKey(String),
+      firstName: String,
+    },
   }
+
   const db = new Database({
-    user: userDefinition,
+    user: dictionary.user,
   })
 
   db.events.on('update', (id, modelName, prevEntity, nextEntity) => {
@@ -68,8 +74,8 @@ test('emits the "update" event when an existing entity is updated', (done) => {
     'user',
     createModel(
       'user',
-      userDefinition,
-      parseModelDefinition('user', userDefinition),
+      dictionary.user,
+      parseModelDefinition(dictionary, 'user', dictionary.user),
       { id: 'abc-123', firstName: 'John' },
       db,
     ),
@@ -79,8 +85,8 @@ test('emits the "update" event when an existing entity is updated', (done) => {
     db.getModel('user').get('abc-123')!,
     createModel(
       'user',
-      userDefinition,
-      parseModelDefinition('user', userDefinition),
+      dictionary.user,
+      parseModelDefinition(dictionary, 'user', dictionary.user),
       { id: 'def-456', firstName: 'Kate' },
       db,
     ),
@@ -88,12 +94,15 @@ test('emits the "update" event when an existing entity is updated', (done) => {
 })
 
 test('emits the "delete" event when an existing entity is deleted', (done) => {
-  const userDefinition = {
-    id: primaryKey(String),
-    firstName: String,
+  const dictionary = {
+    user: {
+      id: primaryKey(String),
+      firstName: String,
+    },
   }
+
   const db = new Database({
-    user: userDefinition,
+    user: dictionary.user,
   })
 
   db.events.on('delete', (id, modelName, primaryKey) => {
@@ -107,8 +116,8 @@ test('emits the "delete" event when an existing entity is deleted', (done) => {
     'user',
     createModel(
       'user',
-      userDefinition,
-      parseModelDefinition('user', userDefinition),
+      dictionary.user,
+      parseModelDefinition(dictionary, 'user', dictionary.user),
       { id: 'abc-123', firstName: 'John' },
       db,
     ),

--- a/test/extensions/sync.test.ts
+++ b/test/extensions/sync.test.ts
@@ -49,8 +49,6 @@ test('synchornizes entity create across multiple clients', async () => {
 
   expect(await secondPage.evaluate(() => window.db.user.getAll())).toEqual([
     {
-      __type: 'user',
-      __primaryKey: 'id',
       id: 'abc-123',
       firstName: 'John',
     },
@@ -87,8 +85,6 @@ test('synchornizes entity update across multiple clients', async () => {
 
   const expectedUsers = [
     {
-      __type: 'user',
-      __primaryKey: 'id',
       id: 'abc-123',
       firstName: 'Kate',
     },
@@ -139,15 +135,11 @@ test('handles events from multiple database instances separately', async () => {
   await runtime.page.bringToFront()
 
   const john = {
-    __type: 'user',
-    __primaryKey: 'id',
     id: 'abc-123',
     firstName: 'John',
   }
 
   const kate = {
-    __type: 'user',
-    __primaryKey: 'id',
     id: 'def-456',
     firstName: 'Kate',
   }
@@ -208,8 +200,6 @@ test('handles events from multiple databases on different hostnames', async () =
     await firstRuntime.page.evaluate(() => window.db.user.getAll()),
   ).toEqual([
     {
-      __type: 'user',
-      __primaryKey: 'id',
       id: 'abc-123',
       firstName: 'John',
     },

--- a/test/relations/one-to-one.test.ts
+++ b/test/relations/one-to-one.test.ts
@@ -41,7 +41,7 @@ test('supports querying through a one-to-one relational property', () => {
   const usa = db.country.create({
     name: 'United States of America',
   })
-  const washington = db.capital.create({
+  db.capital.create({
     name: 'Washington',
     country: usa,
   })

--- a/test/typings/typings.ts
+++ b/test/typings/typings.ts
@@ -32,14 +32,6 @@ db.user.create({
 
 db.user.create({
   // @ts-expect-error Relational property must reference
-  // a valid entity, not a compatible non-entity object.
-  country: {
-    name: 'Not an actual entity',
-  },
-})
-
-db.user.create({
-  // @ts-expect-error Relational property must reference
   // the exact model type ("country").
   country: db.post.create(),
 })

--- a/test/utils/cleanEntity.test.ts
+++ b/test/utils/cleanEntity.test.ts
@@ -1,24 +1,56 @@
-import { factory, primaryKey } from '../../src'
+import { InternalEntityInstance } from '../../src/glossary'
 import { removeInternalProperties } from '../../src/utils/removeInternalProperties'
 
-const db = factory({
-  user: {
-    id: primaryKey(String),
-    firstName: String,
-  },
-})
-
-beforeAll(() => {
-  db.user.create({
+it('removes internal properties from an entity', () => {
+  const user: InternalEntityInstance<any, any> = {
+    __type: 'user',
+    __primaryKey: 'id',
+    id: 'abc-123',
+    firstName: 'John',
+  }
+  expect(removeInternalProperties(user)).toEqual({
     id: 'abc-123',
     firstName: 'John',
   })
 })
 
-it('removes internal properties from an entity', () => {
-  const user = db.user.findFirst({ where: { id: { equals: 'abc-123' } } })
+it('removes internal properties from an entity with relations', () => {
+  const user: InternalEntityInstance<any, any> = {
+    __type: 'user',
+    __primaryKey: 'id',
+    id: 'abc-123',
+    firstName: 'John',
+    address: {
+      __type: 'address',
+      __primaryKey: 'id',
+      id: 'addr-123',
+      street: 'Broadway',
+    },
+    contacts: [
+      {
+        __type: 'contact',
+        __primaryKey: 'id',
+        id: 'contact-123',
+        type: 'home',
+      },
+      {
+        __type: 'contact',
+        __primaryKey: 'id',
+        id: 'contact-456',
+        type: 'office',
+      },
+    ],
+  }
   expect(removeInternalProperties(user)).toEqual({
     id: 'abc-123',
     firstName: 'John',
+    address: {
+      id: 'addr-123',
+      street: 'Broadway',
+    },
+    contacts: [
+      { id: 'contact-123', type: 'home' },
+      { id: 'contact-456', type: 'office' },
+    ],
   })
 })

--- a/test/utils/isInternalEntity.test.ts
+++ b/test/utils/isInternalEntity.test.ts
@@ -1,0 +1,30 @@
+import { isInternalEntity } from '../../src/utils/isInternalEntity'
+
+it('returns true given an internal entity object', () => {
+  expect(
+    isInternalEntity({
+      __type: 'user',
+      __primaryKey: 'id',
+      id: 'abc-123',
+    }),
+  ).toEqual(true)
+})
+
+it('returns false given a corrupted internal entity object', () => {
+  expect(
+    isInternalEntity({
+      __type: 'user',
+      // Purposefully missing the "__primaryKey" property.
+      id: 'abc-123',
+    }),
+  ).toEqual(false)
+})
+
+it('returns false given an arbitrary object', () => {
+  expect(
+    isInternalEntity({
+      id: 'abc-123',
+      type: 'custom',
+    }),
+  ).toEqual(false)
+})

--- a/test/utils/parseModelDefinition.test.ts
+++ b/test/utils/parseModelDefinition.test.ts
@@ -3,10 +3,13 @@ import { manyOf, oneOf, primaryKey } from '../../src'
 import { RelationKind } from '../../src/glossary'
 
 it('parses a given plain model definition', () => {
-  const result = parseModelDefinition('user', {
-    id: primaryKey(String),
-    firstName: String,
-  })
+  const dictionary = {
+    user: {
+      id: primaryKey(String),
+      firstName: String,
+    },
+  }
+  const result = parseModelDefinition(dictionary, 'user', dictionary.user)
 
   expect(result).toEqual({
     primaryKey: 'id',
@@ -16,12 +19,21 @@ it('parses a given plain model definition', () => {
 })
 
 it('parses a given model definition with relations', () => {
-  const result = parseModelDefinition('user', {
-    id: primaryKey(String),
-    firstName: String,
-    country: oneOf('country', { unique: true }),
-    posts: manyOf('post'),
-  })
+  const dictionary = {
+    user: {
+      id: primaryKey(String),
+      firstName: String,
+      country: oneOf('country', { unique: true }),
+      posts: manyOf('post'),
+    },
+    country: {
+      code: primaryKey(String),
+    },
+    post: {
+      id: primaryKey(String),
+    },
+  }
+  const result = parseModelDefinition(dictionary, 'user', dictionary['user'])
 
   expect(result).toEqual({
     primaryKey: 'id',
@@ -31,22 +43,26 @@ it('parses a given model definition with relations', () => {
         kind: RelationKind.OneOf,
         modelName: 'country',
         unique: true,
+        primaryKey: 'code',
       },
       posts: {
         kind: RelationKind.ManyOf,
         modelName: 'post',
         unique: false,
+        primaryKey: 'id',
       },
     },
   })
 })
 
 it('throws an error when provided a model definition with multiple primary keys', () => {
-  const parse = () =>
-    parseModelDefinition('user', {
+  const dictionary = {
+    user: {
       id: primaryKey(String),
       role: primaryKey(String),
-    })
+    },
+  }
+  const parse = () => parseModelDefinition(dictionary, 'user', dictionary.user)
 
   expect(parse).toThrow(
     'Failed to parse a model definition for "user": cannot have both properties "id" and "role" as a primary key.',
@@ -54,10 +70,12 @@ it('throws an error when provided a model definition with multiple primary keys'
 })
 
 it('throws an error when provided a model definition without a primary key', () => {
-  const parse = () =>
-    parseModelDefinition('user', {
+  const dictionary = {
+    user: {
       firstName: String,
-    })
+    },
+  }
+  const parse = () => parseModelDefinition(dictionary, 'user', dictionary.user)
 
   expect(parse).toThrow(
     'Failed to parse a model definition for "user": no provided properties are marked as a primary key (firstName).',

--- a/test/utils/removeInternalProperties.test.ts
+++ b/test/utils/removeInternalProperties.test.ts
@@ -1,8 +1,8 @@
-import { InternalEntityInstance } from '../../src/glossary'
+import { InternalEntity } from '../../src/glossary'
 import { removeInternalProperties } from '../../src/utils/removeInternalProperties'
 
 it('removes internal properties from a plain entity', () => {
-  const user: InternalEntityInstance<any, any> = {
+  const user: InternalEntity<any, any> = {
     __type: 'user',
     __primaryKey: 'id',
     id: 'abc-123',
@@ -16,7 +16,7 @@ it('removes internal properties from a plain entity', () => {
 })
 
 it('removes internal properties from an entity with relations', () => {
-  const user: InternalEntityInstance<any, any> = {
+  const user: InternalEntity<any, any> = {
     __type: 'user',
     __primaryKey: 'id',
     id: 'abc-123',
@@ -58,7 +58,7 @@ it('removes internal properties from an entity with relations', () => {
 })
 
 it('preserves custom properties starting with a leading "__"', () => {
-  const user: InternalEntityInstance<any, any> = {
+  const user: InternalEntity<any, any> = {
     __type: 'user',
     __primaryKey: 'id',
     __customProperty: true,

--- a/test/utils/removeInternalProperties.test.ts
+++ b/test/utils/removeInternalProperties.test.ts
@@ -1,13 +1,14 @@
 import { InternalEntityInstance } from '../../src/glossary'
 import { removeInternalProperties } from '../../src/utils/removeInternalProperties'
 
-it('removes internal properties from an entity', () => {
+it('removes internal properties from a plain entity', () => {
   const user: InternalEntityInstance<any, any> = {
     __type: 'user',
     __primaryKey: 'id',
     id: 'abc-123',
     firstName: 'John',
   }
+
   expect(removeInternalProperties(user)).toEqual({
     id: 'abc-123',
     firstName: 'John',
@@ -41,6 +42,7 @@ it('removes internal properties from an entity with relations', () => {
       },
     ],
   }
+
   expect(removeInternalProperties(user)).toEqual({
     id: 'abc-123',
     firstName: 'John',
@@ -52,5 +54,19 @@ it('removes internal properties from an entity with relations', () => {
       { id: 'contact-123', type: 'home' },
       { id: 'contact-456', type: 'office' },
     ],
+  })
+})
+
+it('preserves custom properties starting with a leading "__"', () => {
+  const user: InternalEntityInstance<any, any> = {
+    __type: 'user',
+    __primaryKey: 'id',
+    __customProperty: true,
+    id: 'abc-123',
+  }
+
+  expect(removeInternalProperties(user)).toEqual({
+    __customProperty: true,
+    id: 'abc-123',
   })
 })


### PR DESCRIPTION
In this PR I have removed all the internals from API.
To do so I have removed remove coupling of api with itself and add the map transformation on different method returns.

I have also removed the map from the rest handlers because it is already done in the api.

I have created a new `Entity` type, the public one, and replaced the old one with `InternalEntity`.

## GitHub

- Closes #41

## Changes

- Separates entities in `Entity` and `InternalEntity`.
- Adds an enum type for internal entity properties (`__type`, `__primaryKey`, etc.).
- Removes internal entity properties from public entities (i.e. from `db[model].create()` return payload).
- Sets `primaryKey` on the `Relation` when it's defined by looking it up in the database for the referenced model.
- Resolves relational properties against the `Relation` with no internal properties on the actual value (no longer needed, relation contains all the necessary info).
- Makes defined relational object properties _enumerable_ (#78).