### PR TITLE
Parses model definition when creating the model API

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ npm install @mswjs/data --save-dev
 
 ### Describe data
 
-With this library, you're modeling data using the `factory` function. That function accepts an object where each key represents a _model name_ and the values are _model declarations_. A model declaration is an object where the keys represent model properties and the values are value getters.
+With this library, you're modeling data using the `factory` function. That function accepts an object where each key represents a _model name_ and the values are _model definitions_. A model definition is an object where the keys represent model properties and the values are value getters.
 
 ```js
 // src/mocks/db.js

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -63,7 +63,7 @@ export type ManyOf<ModelName extends KeyType> = RelationDefinition<
   ModelName
 >
 
-export type ModelDeclaration = Record<
+export type ModelDefinition = Record<
   string,
   (() => BaseTypes) | OneOf<any> | ManyOf<any> | PrimaryKeyDeclaration
 >

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -32,11 +32,10 @@ export interface RelationDefinition<
   modelName: ModelName
 }
 
-export interface Relation<ModelName extends string> {
+export interface Relation {
   kind: RelationKind
   modelName: string
   unique: boolean
-  refs: RelationRef<ModelName>[]
 }
 
 /**

--- a/src/model/generateGraphQLHandlers.ts
+++ b/src/model/generateGraphQLHandlers.ts
@@ -16,7 +16,7 @@ import {
   GraphQLFieldConfigArgumentMap,
 } from 'graphql'
 import { GraphQLHandler, graphql } from 'msw'
-import { ModelAPI, ModelDeclaration, ModelDictionary } from '../glossary'
+import { ModelAPI, ModelDefinition, ModelDictionary } from '../glossary'
 import { capitalize } from '../utils/capitalize'
 import { QueryToComparator } from '../query/queryTypes'
 import { booleanComparators } from '../comparators/boolean'
@@ -102,10 +102,10 @@ export function getQueryTypeByValueType(
   }
 }
 
-export function declarationToFields(
-  declaration: ModelDeclaration,
+export function definitionToFields(
+  definition: ModelDefinition,
 ): GraphQLFieldsMap {
-  return Object.entries(declaration).reduce<GraphQLFieldsMap>(
+  return Object.entries(definition).reduce<GraphQLFieldsMap>(
     (types, [key, value]) => {
       const isPrimaryKey = 'isPrimaryKey' in value
       const valueType = isPrimaryKey ? GraphQLID : getGraphQLType(value)
@@ -137,15 +137,15 @@ export function generateGraphQLHandlers<
   ModelName extends string
 >(
   modelName: ModelName,
-  declaration: ModelDeclaration,
+  definition: ModelDefinition,
   model: ModelAPI<Dictionary, ModelName>,
   baseUrl: string = '',
 ): GraphQLHandler[] {
   const target = baseUrl ? graphql.link(baseUrl) : graphql
   const pluralModelName = pluralize(modelName)
   const capitalModelName = capitalize(modelName)
-  const { fields, inputFields, queryInputFields } = declarationToFields(
-    declaration,
+  const { fields, inputFields, queryInputFields } = definitionToFields(
+    definition,
   )
 
   const EntityType = new GraphQLObjectType({

--- a/src/model/parseModelDefinition.ts
+++ b/src/model/parseModelDefinition.ts
@@ -5,35 +5,35 @@ import {
   RelationDefinition,
   ModelDictionary,
   Value,
-  ModelDeclaration,
+  ModelDefinition,
   PrimaryKeyType,
   EntityInstance,
 } from '../glossary'
 import { invariant } from '../utils/invariant'
 
-const log = debug('parseModelDeclaration')
+const log = debug('parseModelDefinition')
 
-interface ParsedModelDeclaration {
+interface ParsedModelDefinition {
   primaryKey?: PrimaryKeyType
   properties: Value<any, any>
   relations: Record<string, Relation<string>>
 }
 
-export function parseModelDeclaration<
+export function parseModelDefinition<
   Dictionary extends ModelDictionary,
   ModelName extends string
 >(
   modelName: ModelName,
-  declaration: ModelDeclaration,
+  definition: ModelDefinition,
   initialValues?: Partial<Value<Dictionary[ModelName], Dictionary>>,
-): ParsedModelDeclaration {
+): ParsedModelDefinition {
   log(
-    `parsing model declaration for "${modelName}" entity`,
-    declaration,
+    `parsing model definition for "${modelName}" entity`,
+    definition,
     initialValues,
   )
 
-  const result = Object.entries(declaration).reduce<ParsedModelDeclaration>(
+  const result = Object.entries(definition).reduce<ParsedModelDefinition>(
     (acc, [key, valueGetter]) => {
       const exactValue = initialValues?.[key]
       log(`initial value for key "${modelName}.${key}"`, exactValue)
@@ -41,7 +41,7 @@ export function parseModelDeclaration<
       if ('isPrimaryKey' in valueGetter) {
         invariant(
           !!acc.primaryKey,
-          `Failed to parse model declaration for "${modelName}": cannot specify more than one primary key for a model.`,
+          `Failed to parse model definition for "${modelName}": cannot specify more than one primary key for a model.`,
         )
 
         log(`using "${key}" as the primary key for "${modelName}"`)
@@ -66,7 +66,7 @@ export function parseModelDeclaration<
         return acc
       }
 
-      const relationDefinition = declaration[key] as RelationDefinition<
+      const relationDefinition = definition[key] as RelationDefinition<
         RelationKind.OneOf,
         ModelName
       >
@@ -136,7 +136,7 @@ export function parseModelDeclaration<
       )
 
       // When initial value is not provided, use the value getter function
-      // specified in the model declaration.
+      // specified in the model definition.
       acc.properties[key] = valueGetter()
       return acc
     },
@@ -147,10 +147,10 @@ export function parseModelDeclaration<
     },
   )
 
-  // Primary key is required on each model declaration.
+  // Primary key is required on each model definition.
   if (result.primaryKey == null) {
     throw new Error(
-      `Failed to parse model declaration for "${modelName}": primary key not found.`,
+      `Failed to parse model definition for "${modelName}": primary key not found.`,
     )
   }
 

--- a/src/model/parseModelDefinition.ts
+++ b/src/model/parseModelDefinition.ts
@@ -2,155 +2,70 @@ import { debug } from 'debug'
 import {
   Relation,
   RelationKind,
-  RelationDefinition,
-  ModelDictionary,
-  Value,
   ModelDefinition,
   PrimaryKeyType,
-  EntityInstance,
 } from '../glossary'
 import { invariant } from '../utils/invariant'
 
 const log = debug('parseModelDefinition')
 
-interface ParsedModelDefinition {
-  primaryKey?: PrimaryKeyType
-  properties: Value<any, any>
-  relations: Record<string, Relation<string>>
+export interface ParsedModelDefinition {
+  primaryKey: PrimaryKeyType
+  properties: string[]
+  relations: Record<string, Relation>
 }
 
-export function parseModelDefinition<
-  Dictionary extends ModelDictionary,
-  ModelName extends string
->(
-  modelName: ModelName,
+export function parseModelDefinition(
+  modelName: string,
   definition: ModelDefinition,
-  initialValues?: Partial<Value<Dictionary[ModelName], Dictionary>>,
 ): ParsedModelDefinition {
-  log(
-    `parsing model definition for "${modelName}" entity`,
-    definition,
-    initialValues,
-  )
+  log(`parsing model definition for "${modelName}" entity`, definition)
 
-  const result = Object.entries(definition).reduce<ParsedModelDefinition>(
-    (acc, [key, valueGetter]) => {
-      const exactValue = initialValues?.[key]
-      log(`initial value for key "${modelName}.${key}"`, exactValue)
-
+  const result = Object.entries(definition).reduce<{
+    primaryKey: string
+    properties: string[]
+    relations: Record<string, Relation>
+  }>(
+    (result, [property, valueGetter]) => {
       if ('isPrimaryKey' in valueGetter) {
         invariant(
-          !!acc.primaryKey,
-          `Failed to parse model definition for "${modelName}": cannot specify more than one primary key for a model.`,
+          result.primaryKey,
+          `Failed to parse a model definition for "${modelName}": cannot have both properties "${result.primaryKey}" and "${property}" as a primary key.`,
         )
 
-        log(`using "${key}" as the primary key for "${modelName}"`)
-
-        acc.primaryKey = key
-        acc.properties[key] = exactValue || valueGetter.getValue()
-        return acc
+        result.primaryKey = property
+        result.properties.push(property)
+        return result
       }
 
       if (
-        typeof exactValue === 'string' ||
-        typeof exactValue === 'number' ||
-        typeof exactValue === 'boolean' ||
-        (exactValue as any)?.constructor.name === 'Date'
+        'kind' in valueGetter &&
+        [RelationKind.OneOf, RelationKind.ManyOf].includes(valueGetter.kind)
       ) {
-        log(
-          `"${modelName}.${key}" has a plain initial value, setting to`,
-          exactValue,
-        )
-
-        acc.properties[key] = exactValue
-        return acc
-      }
-
-      const relationDefinition = definition[key] as RelationDefinition<
-        RelationKind.OneOf,
-        ModelName
-      >
-
-      if (exactValue) {
-        if (Array.isArray(exactValue)) {
-          /**
-           * @fixme Differentiate between array of references,
-           * array of exact values, and a mixed array of two.
-           */
-          acc.relations[key] = {
-            kind: RelationKind.ManyOf,
-            modelName: relationDefinition.modelName,
-            unique: relationDefinition.unique,
-            refs: exactValue.map(
-              (entityRef: EntityInstance<Dictionary, ModelName>) => ({
-                __type: entityRef.__type,
-                __primaryKey: entityRef.__primaryKey,
-                __nodeId: entityRef[entityRef.__primaryKey],
-              }),
-            ),
-          }
-
-          return acc
+        result.relations[property] = {
+          kind: valueGetter.kind,
+          modelName: valueGetter.modelName,
+          unique: valueGetter.unique,
         }
 
-        if ('__primaryKey' in exactValue) {
-          const entityRef = exactValue
-
-          log(
-            `value for "${modelName}.${key}" references "${
-              entityRef.__type
-            }" with id "${entityRef[entityRef.__primaryKey]}"`,
-            entityRef,
-          )
-
-          acc.relations[key] = {
-            kind: RelationKind.OneOf,
-            modelName: relationDefinition.modelName,
-            unique: relationDefinition.unique,
-            refs: [
-              {
-                __type: entityRef.__type,
-                __primaryKey: entityRef.__primaryKey,
-                __nodeId: entityRef[entityRef.__primaryKey],
-              },
-            ],
-          }
-
-          return acc
-        }
-
-        // A plain exact initial value is provided (not a relational property).
-        acc.properties[key] = exactValue
-        return acc
+        return result
       }
 
-      if ('kind' in valueGetter) {
-        throw new Error(
-          `Failed to set "${modelName}.${key}" as it's a relational property with no value.`,
-        )
-      }
-
-      log(
-        `"${modelName}.${key}" has no initial value, seeding with`,
-        valueGetter,
-      )
-
-      // When initial value is not provided, use the value getter function
-      // specified in the model definition.
-      acc.properties[key] = valueGetter()
-      return acc
+      result.properties.push(property)
+      return result
     },
     {
-      primaryKey: undefined,
-      properties: {},
+      primaryKey: undefined!,
+      properties: [],
       relations: {},
     },
   )
 
-  // Primary key is required on each model definition.
-  if (result.primaryKey == null) {
+  if (!result.primaryKey) {
     throw new Error(
-      `Failed to parse model definition for "${modelName}": primary key not found.`,
+      `Failed to parse a model definition for "${modelName}": no provided properties are marked as a primary key (${result.properties.join(
+        ', ',
+      )}).`,
     )
   }
 

--- a/src/model/parseModelDefinition.ts
+++ b/src/model/parseModelDefinition.ts
@@ -126,7 +126,7 @@ export function parseModelDefinition<
 
       if ('kind' in valueGetter) {
         throw new Error(
-          `Failed to set "${modelName}.${key}" as its a relational property with no value.`,
+          `Failed to set "${modelName}.${key}" as it's a relational property with no value.`,
         )
       }
 

--- a/src/model/updateEntity.ts
+++ b/src/model/updateEntity.ts
@@ -11,7 +11,7 @@ export function updateEntity(
   return Object.entries(data).reduce<EntityInstance<any, any>>(
     (acc, [key, value]) => {
       // Ignore attempts to update entity with properties
-      // that were not specified in the model declaration.
+      // that were not specified in the model definition.
       if (!entity.hasOwnProperty(key)) {
         return acc
       }

--- a/src/utils/findPrimaryKey.ts
+++ b/src/utils/findPrimaryKey.ts
@@ -1,16 +1,16 @@
-import { ModelDeclaration, PrimaryKeyType } from '../glossary'
+import { ModelDefinition, PrimaryKeyType } from '../glossary'
 
 /**
- * Returns a primary key property name of the given model declaration.
+ * Returns a primary key property name of the given model definition.
  */
 export function findPrimaryKey(
-  declaration: ModelDeclaration,
+  definition: ModelDefinition,
 ): PrimaryKeyType | undefined {
-  for (const propName in declaration) {
-    const props = declaration[propName]
+  for (const propertyName in definition) {
+    const values = definition[propertyName]
 
-    if ('isPrimaryKey' in props) {
-      return propName
+    if ('isPrimaryKey' in values) {
+      return propertyName
     }
   }
 }

--- a/test/db/events.test.ts
+++ b/test/db/events.test.ts
@@ -1,12 +1,14 @@
 import { primaryKey } from '@mswjs/data'
 import { Database } from '../../src/db/Database'
 import { createModel } from '../../src/model/createModel'
+import { parseModelDefinition } from '../../src/model/parseModelDefinition'
 
 test('emits the "create" event when a new entity is created', (done) => {
+  const userDefinition = {
+    id: primaryKey(String),
+  }
   const db = new Database({
-    user: {
-      id: primaryKey(String),
-    },
+    user: userDefinition,
   })
 
   db.events.on('create', (id, modelName, entity, primaryKey) => {
@@ -21,15 +23,27 @@ test('emits the "create" event when a new entity is created', (done) => {
     done()
   })
 
-  db.create('user', createModel('user', 'id', { id: 'abc-123' }, {}, db))
+  db.create(
+    'user',
+    createModel(
+      'user',
+      userDefinition,
+      parseModelDefinition('user', userDefinition),
+      {
+        id: 'abc-123',
+      },
+      db,
+    ),
+  )
 })
 
 test('emits the "update" event when an existing entity is updated', (done) => {
+  const userDefinition = {
+    id: primaryKey(String),
+    firstName: String,
+  }
   const db = new Database({
-    user: {
-      id: primaryKey(String),
-      firstName: String,
-    },
+    user: userDefinition,
   })
 
   db.events.on('update', (id, modelName, prevEntity, nextEntity) => {
@@ -52,21 +66,34 @@ test('emits the "update" event when an existing entity is updated', (done) => {
 
   db.create(
     'user',
-    createModel('user', 'id', { id: 'abc-123', firstName: 'John' }, {}, db),
+    createModel(
+      'user',
+      userDefinition,
+      parseModelDefinition('user', userDefinition),
+      { id: 'abc-123', firstName: 'John' },
+      db,
+    ),
   )
   db.update(
     'user',
     db.getModel('user').get('abc-123')!,
-    createModel('user', 'id', { id: 'def-456', firstName: 'Kate' }, {}, db),
+    createModel(
+      'user',
+      userDefinition,
+      parseModelDefinition('user', userDefinition),
+      { id: 'def-456', firstName: 'Kate' },
+      db,
+    ),
   )
 })
 
 test('emits the "delete" event when an existing entity is deleted', (done) => {
+  const userDefinition = {
+    id: primaryKey(String),
+    firstName: String,
+  }
   const db = new Database({
-    user: {
-      id: primaryKey(String),
-      firstName: String,
-    },
+    user: userDefinition,
   })
 
   db.events.on('delete', (id, modelName, primaryKey) => {
@@ -78,7 +105,13 @@ test('emits the "delete" event when an existing entity is deleted', (done) => {
 
   db.create(
     'user',
-    createModel('user', 'id', { id: 'abc-123', firstName: 'John' }, {}, db),
+    createModel(
+      'user',
+      userDefinition,
+      parseModelDefinition('user', userDefinition),
+      { id: 'abc-123', firstName: 'John' },
+      db,
+    ),
   )
   db.delete('user', 'abc-123')
 })

--- a/test/model/toRestHandlers.test.ts
+++ b/test/model/toRestHandlers.test.ts
@@ -219,7 +219,7 @@ describe('POST /users', () => {
     expect(res.status).toEqual(409)
     expect(json).toEqual({
       message:
-        'Failed to create "user": entity with the primary key "abc-123" ("id") already exists.',
+        'Failed to create a "user" entity: an entity with the same primary key "abc-123" ("id") already exists.',
     })
   })
 })

--- a/test/primaryKey.test.ts
+++ b/test/primaryKey.test.ts
@@ -123,7 +123,7 @@ test('throws an exception when creating entity with existing primary key', () =>
   }).toThrowError(
     new OperationError(
       OperationErrorType.DuplicatePrimaryKey,
-      'Failed to create "user": entity with the primary key "abc-123" ("id") already exists.',
+      'Failed to create a "user" entity: an entity with the same primary key "abc-123" ("id") already exists.',
     ),
   )
 })

--- a/test/relations/one-to-one.test.ts
+++ b/test/relations/one-to-one.test.ts
@@ -1,7 +1,7 @@
 import { random } from 'faker'
 import { factory, primaryKey, oneOf } from '@mswjs/data'
 
-test('supports one-to-one relation', () => {
+test.only('supports one-to-one relation', () => {
   const db = factory({
     country: {
       id: primaryKey(random.uuid),

--- a/test/utils/findPrimaryKey.test.ts
+++ b/test/utils/findPrimaryKey.test.ts
@@ -1,6 +1,6 @@
 import { findPrimaryKey } from '../../src/utils/findPrimaryKey'
 
-it('returns the primary key property name of the model declaration', () => {
+it('returns the primary key property name of the model definition', () => {
   const primaryKey = findPrimaryKey({
     id: {
       isPrimaryKey: true,
@@ -10,7 +10,7 @@ it('returns the primary key property name of the model declaration', () => {
   expect(primaryKey).toEqual('id')
 })
 
-it('returns undefined if the model declaration has no primart key', () => {
+it('returns undefined if the model definition has no primart key', () => {
   const primaryKey = findPrimaryKey({})
   expect(primaryKey).toBeUndefined()
 })

--- a/test/utils/generateGraphQLHandlers.test.ts
+++ b/test/utils/generateGraphQLHandlers.test.ts
@@ -10,7 +10,7 @@ import {
   comparatorTypes,
   getGraphQLType,
   getQueryTypeByValueType,
-  declarationToFields,
+  definitionToFields,
 } from '../../src/model/generateGraphQLHandlers'
 
 describe('getGraphQLType', () => {
@@ -53,10 +53,10 @@ describe('getQueryTypeByValueType', () => {
   })
 })
 
-describe('declarationToFields', () => {
-  it('derives fields, input fields, and query input fields from a model declaration', () => {
+describe('definitionToFields', () => {
+  it('derives fields, input fields, and query input fields from a model definition', () => {
     expect(
-      declarationToFields({
+      definitionToFields({
         id: primaryKey(String),
         firstName: String,
         age: Number,

--- a/test/utils/parseModelDefinition.test.ts
+++ b/test/utils/parseModelDefinition.test.ts
@@ -10,78 +10,32 @@ it('parses a given plain model definition', () => {
 
   expect(result).toEqual({
     primaryKey: 'id',
-    properties: {
-      id: '',
-      firstName: '',
-    },
+    properties: ['id', 'firstName'],
     relations: {},
   })
 })
 
 it('parses a given model definition with relations', () => {
-  const result = parseModelDefinition(
-    'user',
-    {
-      id: primaryKey(String),
-      country: oneOf('country', { unique: true }),
-      posts: manyOf('post'),
-    },
-    {
-      id: 'abc-123',
-      country: {
-        __type: 'country',
-        __primaryKey: 'id',
-        id: 'country-1',
-      },
-      posts: [
-        {
-          __type: 'post',
-          __primaryKey: 'id',
-          id: 'post-1',
-        },
-        {
-          __type: 'post',
-          __primaryKey: 'id',
-          id: 'post-2',
-        },
-      ],
-    },
-  )
+  const result = parseModelDefinition('user', {
+    id: primaryKey(String),
+    firstName: String,
+    country: oneOf('country', { unique: true }),
+    posts: manyOf('post'),
+  })
 
   expect(result).toEqual({
     primaryKey: 'id',
-    properties: {
-      id: 'abc-123',
-    },
+    properties: ['id', 'firstName'],
     relations: {
       country: {
         kind: RelationKind.OneOf,
         modelName: 'country',
         unique: true,
-        refs: [
-          {
-            __type: 'country',
-            __primaryKey: 'id',
-            __nodeId: 'country-1',
-          },
-        ],
       },
       posts: {
         kind: RelationKind.ManyOf,
         modelName: 'post',
         unique: false,
-        refs: [
-          {
-            __type: 'post',
-            __primaryKey: 'id',
-            __nodeId: 'post-1',
-          },
-          {
-            __type: 'post',
-            __primaryKey: 'id',
-            __nodeId: 'post-2',
-          },
-        ],
       },
     },
   })
@@ -95,7 +49,7 @@ it('throws an error when provided a model definition with multiple primary keys'
     })
 
   expect(parse).toThrow(
-    'Failed to parse model definition for "user": cannot specify more than one primary key for a model.',
+    'Failed to parse a model definition for "user": cannot have both properties "id" and "role" as a primary key.',
   )
 })
 
@@ -106,18 +60,6 @@ it('throws an error when provided a model definition without a primary key', () 
     })
 
   expect(parse).toThrow(
-    'Failed to parse model definition for "user": primary key not found.',
-  )
-})
-
-it('throws an error when provided a model with relational property but without value', () => {
-  const parse = () =>
-    parseModelDefinition('user', {
-      id: primaryKey(String),
-      country: oneOf('country'),
-    })
-
-  expect(parse).toThrow(
-    `Failed to set "user.country" as it's a relational property with no value.`,
+    'Failed to parse a model definition for "user": no provided properties are marked as a primary key (firstName).',
   )
 })

--- a/test/utils/parseModelDefinition.test.ts
+++ b/test/utils/parseModelDefinition.test.ts
@@ -1,0 +1,123 @@
+import { parseModelDefinition } from '../../src/model/parseModelDefinition'
+import { manyOf, oneOf, primaryKey } from '../../src'
+import { RelationKind } from '../../src/glossary'
+
+it('parses a given plain model definition', () => {
+  const result = parseModelDefinition('user', {
+    id: primaryKey(String),
+    firstName: String,
+  })
+
+  expect(result).toEqual({
+    primaryKey: 'id',
+    properties: {
+      id: '',
+      firstName: '',
+    },
+    relations: {},
+  })
+})
+
+it('parses a given model definition with relations', () => {
+  const result = parseModelDefinition(
+    'user',
+    {
+      id: primaryKey(String),
+      country: oneOf('country', { unique: true }),
+      posts: manyOf('post'),
+    },
+    {
+      id: 'abc-123',
+      country: {
+        __type: 'country',
+        __primaryKey: 'id',
+        id: 'country-1',
+      },
+      posts: [
+        {
+          __type: 'post',
+          __primaryKey: 'id',
+          id: 'post-1',
+        },
+        {
+          __type: 'post',
+          __primaryKey: 'id',
+          id: 'post-2',
+        },
+      ],
+    },
+  )
+
+  expect(result).toEqual({
+    primaryKey: 'id',
+    properties: {
+      id: 'abc-123',
+    },
+    relations: {
+      country: {
+        kind: RelationKind.OneOf,
+        modelName: 'country',
+        unique: true,
+        refs: [
+          {
+            __type: 'country',
+            __primaryKey: 'id',
+            __nodeId: 'country-1',
+          },
+        ],
+      },
+      posts: {
+        kind: RelationKind.ManyOf,
+        modelName: 'post',
+        unique: false,
+        refs: [
+          {
+            __type: 'post',
+            __primaryKey: 'id',
+            __nodeId: 'post-1',
+          },
+          {
+            __type: 'post',
+            __primaryKey: 'id',
+            __nodeId: 'post-2',
+          },
+        ],
+      },
+    },
+  })
+})
+
+it('throws an error when provided a model definition with multiple primary keys', () => {
+  const parse = () =>
+    parseModelDefinition('user', {
+      id: primaryKey(String),
+      role: primaryKey(String),
+    })
+
+  expect(parse).toThrow(
+    'Failed to parse model definition for "user": cannot specify more than one primary key for a model.',
+  )
+})
+
+it('throws an error when provided a model definition without a primary key', () => {
+  const parse = () =>
+    parseModelDefinition('user', {
+      firstName: String,
+    })
+
+  expect(parse).toThrow(
+    'Failed to parse model definition for "user": primary key not found.',
+  )
+})
+
+it('throws an error when provided a model with relational property but without value', () => {
+  const parse = () =>
+    parseModelDefinition('user', {
+      id: primaryKey(String),
+      country: oneOf('country'),
+    })
+
+  expect(parse).toThrow(
+    `Failed to set "user.country" as it's a relational property with no value.`,
+  )
+})


### PR DESCRIPTION
## GitHub

- Closes #71 

## Changes

Consistently adopts the term _model definition_, not declaration. 

Now parsing of the model happens when its API is created (previously when each entity is created). This helps to extract metadata from the model without having to wait until an entity is created. 

Relations no longer have `refs`, instead are resolved from the parsed model (`oneOf`/`manyOf` still return a relational object) and the initial value used to query that relational entity. 