### PR TITLE
Add generic type to getAll

### DIFF
--- a/src/db/Database.ts
+++ b/src/db/Database.ts
@@ -23,11 +23,11 @@ let callOrder = 0
 export class Database<Dictionary extends ModelDictionary> {
   public id: string
   public events: StrictEventEmitter<DatabaseEventsMap>
-  private models: Models<ModelDictionary>
+  private models: Models<Dictionary>
 
   constructor(dictionary: Dictionary) {
     this.events = new StrictEventEmitter()
-    this.models = Object.keys(dictionary).reduce<Models<ModelDictionary>>(
+    this.models = Object.keys(dictionary).reduce<Models<Dictionary>>(
       (acc, modelName) => {
         acc[modelName] = new Map<string, EntityInstance<Dictionary, string>>()
         return acc
@@ -51,12 +51,12 @@ export class Database<Dictionary extends ModelDictionary> {
     return md5(salt)
   }
 
-  getModel(name: string) {
+  getModel<ModelName extends string>(name: ModelName) {
     return this.models[name]
   }
 
-  create(
-    modelName: string,
+  create<ModelName extends string>(
+    modelName: ModelName,
     entity: EntityInstance<Dictionary, any>,
     customPrimaryKey?: PrimaryKeyType,
   ) {
@@ -68,10 +68,10 @@ export class Database<Dictionary extends ModelDictionary> {
     return this.getModel(modelName).set(primaryKey, entity)
   }
 
-  update(
-    modelName: string,
-    prevEntity: EntityInstance<Dictionary, any>,
-    nextEntity: EntityInstance<Dictionary, any>,
+  update<ModelName extends string>(
+    modelName: ModelName,
+    prevEntity: EntityInstance<Dictionary, ModelName>,
+    nextEntity: EntityInstance<Dictionary, ModelName>,
   ) {
     const prevPrimaryKey = prevEntity[prevEntity.__primaryKey]
     const nextPrimaryKey = nextEntity[prevEntity.__primaryKey]
@@ -84,20 +84,28 @@ export class Database<Dictionary extends ModelDictionary> {
     this.events.emit('update', this.id, modelName, prevEntity, nextEntity)
   }
 
-  has(modelName: string, primaryKey: PrimaryKeyType) {
+  has<ModelName extends string>(
+    modelName: ModelName,
+    primaryKey: PrimaryKeyType,
+  ) {
     return this.getModel(modelName).has(primaryKey)
   }
 
-  count(modelName: string) {
+  count<ModelName extends string>(modelName: ModelName) {
     return this.getModel(modelName).size
   }
 
-  delete(modelName: string, primaryKey: PrimaryKeyType) {
+  delete<ModelName extends string>(
+    modelName: ModelName,
+    primaryKey: PrimaryKeyType,
+  ) {
     this.getModel(modelName).delete(primaryKey)
     this.events.emit('delete', this.id, modelName, primaryKey)
   }
 
-  listEntities(modelName: string) {
+  listEntities<ModelName extends string>(
+    modelName: ModelName,
+  ): EntityInstance<Dictionary, ModelName>[] {
     return Array.from(this.getModel(modelName).values())
   }
 }

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -129,7 +129,7 @@ export interface ModelAPI<
   /**
    * Return all entities of the current model.
    */
-  getAll(): EntityInstance<Limit<Record<string, Record<string, any>>>, any>[]
+  getAll(): EntityInstance<Dictionary, ModelName>[]
   /**
    * Update a single entity with the next data.
    */

--- a/test/typings/typings.ts
+++ b/test/typings/typings.ts
@@ -98,3 +98,12 @@ db.user.update({
     },
   },
 })
+
+db.user.getAll().map((user) => {
+  user.id
+  user.firstName
+  user.country
+
+  // @ts-expect-error Unknown property "foo" on the "user" model.
+  user.foo
+})


### PR DESCRIPTION
Previously, getAll returned the type `any[]`, even though it returned additional properties. Now, the entity type is correctly inferred (similar to `findFirst`, `findMany`, etc.).