### PR TITLE
chore: add @mswjs/data as a module

### DIFF
--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,10 +1,9 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "strict": true,
+    "declaration": false,
     "noEmit": true,
-    "esModuleInterop": true,
-    "downlevelIteration": true
+    "baseUrl": "../"
   },
   "include": ["**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "esModuleInterop": true,
     "baseUrl": ".",
     "paths": {
-      "@mswjs/data": ["."]
+      "@mswjs/data": ["./lib"]
     }
   },
   "include": ["src/**/*.ts"],


### PR DESCRIPTION
In tests `@mswjs/data` is imported from the lib folder.
It was giving a type error because the test folder was not include in tsconfig.