### PR TITLE
Add async tests for findFirst and findMany

### DIFF
--- a/test/model/findFirst.test.ts
+++ b/test/model/findFirst.test.ts
@@ -1,5 +1,5 @@
-import { datatype } from 'faker'
-import { factory, primaryKey } from '@mswjs/data'
+import { datatype, seed } from 'faker'
+import { factory, oneOf, primaryKey } from '@mswjs/data'
 import { OperationErrorType } from '../../src/errors/OperationError'
 import { identity } from '../../src/utils/identity'
 import { getThrownError } from '../testUtils'
@@ -89,4 +89,60 @@ test('returns null when found no matching entities', () => {
     },
   })
   expect(user).toBeNull()
+})
+
+// See: https://github.com/mswjs/data/issues/78
+test('returns same results in setTimeout', async () => {
+  const db = factory({
+    user: {
+      id: primaryKey(datatype.uuid),
+      firstName: String,
+    },
+    userObject: {
+      id: primaryKey(datatype.uuid),
+      data: String,
+      user: oneOf('user'),
+    },
+  })
+
+  // Seed the database
+  const seededUser = db.user.create({
+    firstName: 'Test',
+  })
+  const seededObject = db.userObject.create({
+    user: seededUser,
+    data: 'test data - associated with user',
+  })
+
+  const queryObject = () => {
+    const object = db.userObject.findFirst({
+      where: {
+        user: {
+          id: {
+            equals: seededUser.id,
+          },
+        },
+      },
+    })
+    expect(object).toEqual({
+      data: 'test data - associated with user',
+      id: seededObject.id,
+      user: {
+        id: seededUser.id,
+        firstName: 'Test',
+      },
+    })
+  }
+
+  // Query for the object immediately
+  queryObject()
+
+  // This should return the exact same results as the query above,
+  // since nothing has changed
+  await new Promise<void>((res) =>
+    setTimeout(() => {
+      queryObject()
+      res()
+    }, 1000),
+  )
 })

--- a/test/model/findFirst.test.ts
+++ b/test/model/findFirst.test.ts
@@ -1,4 +1,4 @@
-import { datatype, seed } from 'faker'
+import { datatype } from 'faker'
 import { factory, oneOf, primaryKey } from '@mswjs/data'
 import { OperationErrorType } from '../../src/errors/OperationError'
 import { identity } from '../../src/utils/identity'


### PR DESCRIPTION
Added tests to ensure that both `findFirst` and `findMany` return identical results when called at a later point asynchronously, if no data has been mutated.