### PR TITLE
Add test to assert enumerable relational properties

### DIFF
--- a/test/model/relationalProperties.test.ts
+++ b/test/model/relationalProperties.test.ts
@@ -18,14 +18,14 @@ it('returns an enumerable relation property', () => {
   const db = new Database(dictionary)
 
   db.create('post', {
-    __primaryKey: 'id',
-    __type: 'post',
+    [InternalEntityProperty.primaryKey]: 'id',
+    [InternalEntityProperty.type]: 'post',
     id: 'post-1',
     title: 'First Post',
   })
   db.create('post', {
-    __primaryKey: 'id',
-    __type: 'post',
+    [InternalEntityProperty.primaryKey]: 'id',
+    [InternalEntityProperty.type]: 'post',
     id: 'post-2',
     title: 'Second Post',
   })

--- a/test/model/relationalProperties.test.ts
+++ b/test/model/relationalProperties.test.ts
@@ -1,4 +1,4 @@
-import { manyOf, primaryKey } from '../../src'
+import { manyOf, oneOf, primaryKey } from '../../src'
 import { Database } from '../../src/db/Database'
 import { InternalEntityProperty, Relation } from '../../src/glossary'
 import { defineRelationalProperties } from '../../src/model/defineRelationalProperties'
@@ -7,46 +7,40 @@ it('marks relational properties as enumerable', () => {
   const dictionary = {
     user: {
       id: primaryKey(String),
-      posts: manyOf('post'),
+      name: String,
     },
     post: {
       id: primaryKey(String),
       title: String,
+      author: oneOf('user'),
     },
   }
 
   const db = new Database(dictionary)
 
-  db.create('post', {
+  db.create('user', {
     [InternalEntityProperty.primaryKey]: 'id',
-    [InternalEntityProperty.type]: 'post',
-    id: 'post-1',
-    title: 'First Post',
-  })
-  db.create('post', {
-    [InternalEntityProperty.primaryKey]: 'id',
-    [InternalEntityProperty.type]: 'post',
-    id: 'post-2',
-    title: 'Second Post',
+    [InternalEntityProperty.type]: 'user',
+    id: 'abc-123',
+    name: 'Test User',
   })
 
   const relations: Record<string, Relation> = {
-    posts: {
-      ...dictionary.user.posts,
+    author: {
+      ...dictionary.post.author,
       primaryKey: 'id',
     },
   }
 
-  const user = {
+  const post = {
     [InternalEntityProperty.primaryKey]: 'id',
     [InternalEntityProperty.type]: 'post',
-    id: 'abc-123',
+    id: '234',
+    title: 'Test Post',
   }
-  const initialValues = {
-    posts: [{ id: 'post-1' }, { id: 'post-2' }],
-  }
+  const initialValues = { author: { id: 'abc-123' } }
 
-  defineRelationalProperties(user, initialValues, relations, db)
+  defineRelationalProperties(post, initialValues, relations, db)
 
-  expect(user.propertyIsEnumerable('posts')).toBe(true)
+  expect(post.propertyIsEnumerable('author')).toBe(true)
 })

--- a/test/model/relationalProperties.test.ts
+++ b/test/model/relationalProperties.test.ts
@@ -1,0 +1,52 @@
+import { manyOf, primaryKey } from '../../src'
+import { Database } from '../../src/db/Database'
+import { InternalEntityProperty, Relation } from '../../src/glossary'
+import { defineRelationalProperties } from '../../src/model/defineRelationalProperties'
+
+it('returns an enumerable relation property', () => {
+  const dictionary = {
+    user: {
+      id: primaryKey(String),
+      posts: manyOf('post'),
+    },
+    post: {
+      id: primaryKey(String),
+      title: String,
+    },
+  }
+
+  const db = new Database(dictionary)
+
+  db.create('post', {
+    __primaryKey: 'id',
+    __type: 'post',
+    id: 'post-1',
+    title: 'First Post',
+  })
+  db.create('post', {
+    __primaryKey: 'id',
+    __type: 'post',
+    id: 'post-2',
+    title: 'Second Post',
+  })
+
+  const relations: Record<string, Relation> = {
+    posts: {
+      ...dictionary.user.posts,
+      primaryKey: 'id',
+    },
+  }
+
+  const user = {
+    [InternalEntityProperty.primaryKey]: 'id',
+    [InternalEntityProperty.type]: 'post',
+    id: 'abc-123',
+  }
+  const initialValues = {
+    posts: [{ id: 'post-1' }, { id: 'post-2' }],
+  }
+
+  defineRelationalProperties(user, initialValues, relations, db)
+
+  expect(user.propertyIsEnumerable('posts')).toBe(true)
+})

--- a/test/model/relationalProperties.test.ts
+++ b/test/model/relationalProperties.test.ts
@@ -3,7 +3,7 @@ import { Database } from '../../src/db/Database'
 import { InternalEntityProperty, Relation } from '../../src/glossary'
 import { defineRelationalProperties } from '../../src/model/defineRelationalProperties'
 
-it('returns an enumerable relation property', () => {
+it('marks relational properties as enumerable', () => {
   const dictionary = {
     user: {
       id: primaryKey(String),


### PR DESCRIPTION
Added a test to check that relational properties which get defined on the entity are enumerable. Checks #78 (fix added in #67).