### PR TITLE
Adds integration tests for updating a "manyOf" relational property

### DIFF
--- a/test/regressions/02-handlers-many-of.test.ts
+++ b/test/regressions/02-handlers-many-of.test.ts
@@ -1,19 +1,7 @@
 import fetch from 'node-fetch'
-import { datatype, name, random } from 'faker'
+import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 import { factory, manyOf, primaryKey } from '@mswjs/data'
-
-const db = factory({
-  user: {
-    id: primaryKey(datatype.uuid),
-    firstName: name.firstName,
-    posts: manyOf('post'),
-  },
-  post: {
-    id: primaryKey(datatype.uuid),
-    title: random.words,
-  },
-})
 
 const server = setupServer()
 
@@ -26,51 +14,121 @@ afterAll(() => {
 })
 
 it('updates database entity modified via a generated handler', async () => {
-  const firstPost = db.post.create({
-    title: 'First post',
-  })
-  const secondPost = db.post.create({
-    title: 'Second post',
+  const db = factory({
+    user: {
+      id: primaryKey(String),
+      notes: manyOf('note'),
+    },
+    note: {
+      id: primaryKey(String),
+      title: String,
+    },
   })
 
-  // Create a database entity outside of the generated handlers.
-  // Bind it to a "mayOf" posts relationship.
   db.user.create({
-    id: 'abc-123',
-    firstName: 'John',
-    posts: [firstPost],
+    id: 'user-1',
+    notes: [
+      db.note.create({ id: 'note-1', title: 'First note' }),
+      db.note.create({ id: 'note-2', title: 'Second note' }),
+    ],
   })
 
-  server.use(...db.user.toHandlers('rest', 'http://localhost'))
+  server.use(
+    rest.get('/user', (req, res, ctx) => {
+      const user = db.user.findFirst({
+        strict: true,
+        where: {
+          id: {
+            equals: 'user-1',
+          },
+        },
+      })
+      return res(ctx.json(user))
+    }),
+    rest.put<{ title: string }>('/note/:noteId', (req, res, ctx) => {
+      const { noteId } = req.params
 
-  // Update the previously populated "user" instance
-  // via the generated request handlers.
-  const response = await fetch('http://localhost/users/abc-123', {
+      const updatedNote = db.note.update({
+        strict: true,
+        where: {
+          id: {
+            equals: noteId,
+          },
+        },
+        data: {
+          title: req.body.title,
+        },
+      })
+
+      return res(ctx.json(updatedNote))
+    }),
+  )
+
+  // Update a referenced relational property via request handler.
+  const noteUpdateResponse = await fetch('http://localhost/note/note-2', {
     method: 'PUT',
-    // Pay attention to compose a proper request,
-    // including its "Content-Type" header.
     headers: {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      posts: [secondPost],
+      title: 'Updated title',
     }),
   })
-  const json = await response.json()
-  expect(response.status).toEqual(200)
-  expect(json).toEqual({
-    id: 'abc-123',
-    firstName: 'John',
-    posts: [secondPost],
+  expect(noteUpdateResponse.status).toEqual(200)
+
+  // Updates persist when querying the updated entity directly.
+  expect(
+    db.note.findFirst({
+      where: {
+        id: {
+          equals: 'note-2',
+        },
+      },
+    }),
+  ).toEqual({
+    id: 'note-2',
+    title: 'Updated title',
   })
 
-  // Query the database directly.
-  const user = db.user.findFirst({
-    where: {
-      id: {
-        equals: 'abc-123',
+  // Updates persist when querying a parent entity that references
+  // the updated relational entity.
+  expect(
+    db.user.findFirst({
+      where: {
+        id: {
+          equals: 'user-1',
+        },
       },
-    },
+    }),
+  ).toEqual({
+    id: 'user-1',
+    notes: [
+      {
+        id: 'note-1',
+        title: 'First note',
+      },
+      {
+        id: 'note-2',
+        title: 'Updated title',
+      },
+    ],
   })
-  expect(user).toHaveProperty('posts', [secondPost])
+
+  //
+  const refetchedUser = await fetch('http://localhost/user').then((res) =>
+    res.json(),
+  )
+  expect(refetchedUser).toEqual({
+    id: 'user-1',
+    notes: [
+      {
+        id: 'note-1',
+        title: 'First note',
+      },
+      {
+        id: 'note-2',
+        title: 'Updated title',
+      },
+    ],
+  })
 })

--- a/test/regressions/02-handlers-many-of.test.ts
+++ b/test/regressions/02-handlers-many-of.test.ts
@@ -1,0 +1,76 @@
+import fetch from 'node-fetch'
+import { datatype, name, random } from 'faker'
+import { setupServer } from 'msw/node'
+import { factory, manyOf, primaryKey } from '@mswjs/data'
+
+const db = factory({
+  user: {
+    id: primaryKey(datatype.uuid),
+    firstName: name.firstName,
+    posts: manyOf('post'),
+  },
+  post: {
+    id: primaryKey(datatype.uuid),
+    title: random.words,
+  },
+})
+
+const server = setupServer()
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+it('updates database entity modified via a generated handler', async () => {
+  const firstPost = db.post.create({
+    title: 'First post',
+  })
+  const secondPost = db.post.create({
+    title: 'Second post',
+  })
+
+  // Create a database entity outside of the generated handlers.
+  // Bind it to a "mayOf" posts relationship.
+  db.user.create({
+    id: 'abc-123',
+    firstName: 'John',
+    posts: [firstPost],
+  })
+
+  server.use(...db.user.toHandlers('rest', 'http://localhost'))
+
+  // Update the previously populated "user" instance
+  // via the generated request handlers.
+  const response = await fetch('http://localhost/users/abc-123', {
+    method: 'PUT',
+    // Pay attention to compose a proper request,
+    // including its "Content-Type" header.
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      posts: [secondPost],
+    }),
+  })
+  const json = await response.json()
+  expect(response.status).toEqual(200)
+  expect(json).toEqual({
+    id: 'abc-123',
+    firstName: 'John',
+    posts: [secondPost],
+  })
+
+  // Query the database directly.
+  const user = db.user.findFirst({
+    where: {
+      id: {
+        equals: 'abc-123',
+      },
+    },
+  })
+  expect(user).toHaveProperty('posts', [secondPost])
+})

--- a/test/regressions/02-handlers-many-of.test.ts
+++ b/test/regressions/02-handlers-many-of.test.ts
@@ -114,7 +114,7 @@ it('updates database entity modified via a generated handler', async () => {
     ],
   })
 
-  //
+  // Updates persist in the request handler's mocked response.
   const refetchedUser = await fetch('http://localhost/user').then((res) =>
     res.json(),
   )

--- a/test/relations/one-to-many.test.ts
+++ b/test/relations/one-to-many.test.ts
@@ -91,3 +91,111 @@ test('should not throw error if an entity with one-to-many relation is created w
 
   expect(() => db.user.create()).not.toThrow()
 })
+
+test('updates the relational value via the ".update()" model method', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(random.uuid),
+      posts: manyOf('post'),
+    },
+    post: {
+      id: primaryKey(random.uuid),
+      title: random.words,
+    },
+  })
+
+  const firstPost = db.post.create({ title: 'First post' })
+  const secondPost = db.post.create({ title: 'Second post' })
+  const user = db.user.create({
+    id: 'abc-123',
+    posts: [firstPost],
+  })
+  const refetchUser = () => {
+    return db.user.findFirst({
+      where: {
+        id: { equals: 'abc-123' },
+      },
+    })
+  }
+
+  expect(user.posts).toEqual([firstPost])
+  expect(refetchUser()).toEqual({
+    id: 'abc-123',
+    posts: [firstPost],
+  })
+
+  // Update the "posts" relational property.
+  const updatedUser = db.user.update({
+    where: {
+      id: { equals: 'abc-123' },
+    },
+    data: {
+      posts: [secondPost],
+    },
+  })
+
+  expect(updatedUser).toEqual({
+    id: 'abc-123',
+    posts: [secondPost],
+  })
+  expect(refetchUser()).toEqual({
+    id: 'abc-123',
+    posts: [secondPost],
+  })
+})
+
+test('updates the relational value via a compatible object', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(random.uuid),
+      posts: manyOf('post'),
+    },
+    post: {
+      id: primaryKey(random.uuid),
+      title: random.words,
+    },
+  })
+  const firstPost = db.post.create({ title: 'First post' })
+  const user = db.user.create({
+    id: 'abc-123',
+    posts: [firstPost],
+  })
+  const refetchUser = () => {
+    return db.user.findFirst({
+      where: {
+        id: { equals: 'abc-123' },
+      },
+    })
+  }
+
+  expect(user.posts).toEqual([firstPost])
+  expect(refetchUser()).toEqual({
+    id: 'abc-123',
+    posts: [firstPost],
+  })
+
+  // Update the "posts" relational property
+  // with a compatible direct Object.
+  const directObject = {
+    id: 'post-1',
+    title: 'Compatible post',
+  }
+
+  const updatedUser = db.user.update({
+    where: {
+      id: { equals: 'abc-123' },
+    },
+    data: {
+      posts: [directObject],
+    },
+  })
+
+  expect(updatedUser).toEqual({
+    id: 'abc-123',
+    posts: [directObject],
+  })
+  expect(refetchUser()).toEqual({
+    id: 'abc-123',
+    posts: [directObject],
+  })
+})

--- a/test/relations/one-to-one.test.ts
+++ b/test/relations/one-to-one.test.ts
@@ -73,3 +73,122 @@ test('should not throw error if an entity with one-to-one relation is created wi
 
   expect(() => db.capital.create()).not.toThrow()
 })
+
+test('updates the relational property to the next entity', () => {
+  const db = factory({
+    country: {
+      name: primaryKey(random.words),
+    },
+    capital: {
+      name: primaryKey(random.word),
+      country: oneOf('country'),
+    },
+  })
+  const refetchCapital = () => {
+    return db.capital.findFirst({
+      where: {
+        name: { equals: 'Washington' },
+      },
+    })
+  }
+
+  const usa = db.country.create({
+    name: 'United States of America',
+  })
+  const australia = db.country.create({
+    name: 'Australia',
+  })
+  db.capital.create({
+    name: 'Washington',
+    country: usa,
+  })
+  expect(refetchCapital()).toEqual({
+    name: 'Washington',
+    country: {
+      name: 'United States of America',
+    },
+  })
+
+  // Update the "country" relational property.
+  const updatedCapital = db.capital.update({
+    where: {
+      name: { equals: 'Washington' },
+    },
+    data: {
+      country: australia,
+    },
+  })
+
+  expect(updatedCapital).toEqual({
+    name: 'Washington',
+    country: {
+      name: 'Australia',
+    },
+  })
+  expect(refetchCapital()).toEqual({
+    name: 'Washington',
+    country: {
+      name: 'Australia',
+    },
+  })
+})
+
+test('updates the relational property to a compatible object value', () => {
+  const db = factory({
+    country: {
+      name: primaryKey(random.words),
+    },
+    capital: {
+      name: primaryKey(random.word),
+      country: oneOf('country'),
+    },
+  })
+  const refetchCapital = () => {
+    return db.capital.findFirst({
+      where: {
+        name: { equals: 'Washington' },
+      },
+    })
+  }
+
+  const usa = db.country.create({
+    name: 'United States of America',
+  })
+  db.capital.create({
+    name: 'Washington',
+    country: usa,
+  })
+
+  expect(refetchCapital()).toEqual({
+    name: 'Washington',
+    country: {
+      name: 'United States of America',
+    },
+  })
+
+  // Update the "country" relational property
+  // to a compatible object value.
+  const updatedCapital = db.capital.update({
+    where: {
+      name: { equals: 'Washington' },
+    },
+    data: {
+      country: {
+        name: 'Australia',
+      },
+    },
+  })
+
+  expect(updatedCapital).toEqual({
+    name: 'Washington',
+    country: {
+      name: 'Australia',
+    },
+  })
+  expect(refetchCapital()).toEqual({
+    name: 'Washington',
+    country: {
+      name: 'Australia',
+    },
+  })
+})


### PR DESCRIPTION
- Related to #92 

## Changes

- Adds missing tests for updating a `manyOf` relational property with both entity and a compatible object. 