### PR TITLE
expose graphql schema via `factory.toSchema`

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -266,11 +266,8 @@ function createModelApi<
 
       return generateRestHandlers(modelName, definition, api, baseUrl)
     },
-    toSchema(type: 'graphql') {
-      if (type === 'graphql') {
-        return generateGraphQLSchema(modelName, definition, api)
-      }
-      throw new Error('This Schema type is not supported at the moment')
+    toGraphQLSchema() {
+      return generateGraphQLSchema(modelName, definition, api)
     },
   }
 

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -15,7 +15,10 @@ import { updateEntity } from './model/updateEntity'
 import { OperationError, OperationErrorType } from './errors/OperationError'
 import { Database } from './db/Database'
 import { generateRestHandlers } from './model/generateRestHandlers'
-import { generateGraphQLHandlers } from './model/generateGraphQLHandlers'
+import {
+  generateGraphQLHandlers,
+  generateGraphQLSchema,
+} from './model/generateGraphQLHandlers'
 import { sync } from './extensions/sync'
 import { removeInternalProperties } from './utils/removeInternalProperties'
 
@@ -256,12 +259,18 @@ function createModelApi<
 
       return records.map(removeInternalProperties)
     },
-    toHandlers(type, baseUrl): any {
+    toHandlers(type: 'rest' | 'graphql', baseUrl: string): any {
       if (type === 'graphql') {
         return generateGraphQLHandlers(modelName, definition, api, baseUrl)
       }
 
       return generateRestHandlers(modelName, definition, api, baseUrl)
+    },
+    toSchema(type: 'graphql') {
+      if (type === 'graphql') {
+        return generateGraphQLSchema(modelName, definition, api)
+      }
+      throw new Error('This Schema type is not supported at the moment')
     },
   }
 

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -1,3 +1,4 @@
+import { GraphQLSchema } from 'graphql'
 import { GraphQLHandler, RestHandler } from 'msw'
 import {
   BulkQueryOptions,
@@ -174,10 +175,16 @@ export interface ModelAPI<
   /**
    * Generate request handlers of the given type based on the model.
    */
-  toHandlers<HandlerType extends 'rest' | 'graphql'>(
-    type: HandlerType,
-    baseUrl?: string,
-  ): HandlerType extends 'rest' ? RestHandler[] : GraphQLHandler[]
+  toHandlers(type: 'rest', baseUrl?: string): RestHandler[]
+  /**
+   * Generate request handlers of the given type based on the model.
+   */
+  toHandlers(type: 'graphql', baseUrl?: string): GraphQLHandler[]
+
+  /**
+   * Generate a schema of the given type based on the model.
+   */
+  toSchema(type: 'graphql'): GraphQLSchema
 }
 
 export type UpdateManyValue<

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -182,9 +182,9 @@ export interface ModelAPI<
   toHandlers(type: 'graphql', baseUrl?: string): GraphQLHandler[]
 
   /**
-   * Generate a schema of the given type based on the model.
+   * Generate a graphql schema based on the model.
    */
-  toSchema(type: 'graphql'): GraphQLSchema
+  toGraphQLSchema(): GraphQLSchema
 }
 
 export type UpdateManyValue<

--- a/src/model/generateGraphQLHandlers.ts
+++ b/src/model/generateGraphQLHandlers.ts
@@ -132,16 +132,14 @@ export function definitionToFields(
   )
 }
 
-export function generateGraphQLHandlers<
+export function generateGraphQLSchema<
   Dictionary extends ModelDictionary,
   ModelName extends string
 >(
   modelName: ModelName,
   definition: ModelDefinition,
   model: ModelAPI<Dictionary, ModelName>,
-  baseUrl: string = '',
-): GraphQLHandler[] {
-  const target = baseUrl ? graphql.link(baseUrl) : graphql
+): GraphQLSchema {
   const pluralModelName = pluralize(modelName)
   const capitalModelName = capitalize(modelName)
   const { fields, inputFields, queryInputFields } = definitionToFields(
@@ -267,6 +265,22 @@ export function generateGraphQLHandlers<
       },
     }),
   })
+
+  return objectSchema
+}
+
+export function generateGraphQLHandlers<
+  Dictionary extends ModelDictionary,
+  ModelName extends string
+>(
+  modelName: ModelName,
+  definition: ModelDefinition,
+  model: ModelAPI<Dictionary, ModelName>,
+  baseUrl: string = '',
+): GraphQLHandler[] {
+  const target = baseUrl ? graphql.link(baseUrl) : graphql
+
+  const objectSchema = generateGraphQLSchema(modelName, definition, model)
 
   return [
     target.operation(async (req, res, ctx) => {

--- a/test/model/toGraphQLSchema.test.ts
+++ b/test/model/toGraphQLSchema.test.ts
@@ -1,0 +1,77 @@
+import { datatype } from 'faker'
+import { factory, primaryKey } from '@mswjs/data'
+import { printSchema } from 'graphql'
+
+const db = factory({
+  user: {
+    id: primaryKey(datatype.uuid),
+    firstName: String,
+    age: Number,
+  },
+})
+
+test('generates a graphql schema', () => {
+  const schema = db.user.toSchema('graphql')
+  expect(printSchema(schema)).toMatchInlineSnapshot(`
+    "type Query {
+      user(where: UserQueryInput): User
+      users(take: Int, skip: Int, cursor: ID, where: UserQueryInput): [User]
+    }
+
+    type User {
+      id: ID
+      firstName: String
+      age: Int
+    }
+
+    input UserQueryInput {
+      id: IdQueryType
+      firstName: StringQueryType
+      age: IntQueryType
+    }
+
+    input IdQueryType {
+      equals: ID
+      notEquals: ID
+      contains: ID
+      notContains: ID
+      in: ID
+      notIn: ID
+    }
+
+    input StringQueryType {
+      equals: String
+      notEquals: String
+      contains: String
+      notContains: String
+      in: String
+      notIn: String
+    }
+
+    input IntQueryType {
+      equals: Int
+      notEquals: Int
+      between: Int
+      notBetween: Int
+      gt: Int
+      gte: Int
+      lt: Int
+      lte: Int
+    }
+
+    type Mutation {
+      createUser(data: UserInput): User
+      updateUser(where: UserQueryInput, data: UserInput): User
+      updateUsers(where: UserQueryInput, data: UserInput): [User]
+      deleteUser(where: UserQueryInput): User
+      deleteUsers(where: UserQueryInput): [User]
+    }
+
+    input UserInput {
+      id: ID
+      firstName: String
+      age: Int
+    }
+    "
+  `)
+})

--- a/test/model/toGraphQLSchema.test.ts
+++ b/test/model/toGraphQLSchema.test.ts
@@ -11,7 +11,7 @@ const db = factory({
 })
 
 test('generates a graphql schema', () => {
-  const schema = db.user.toSchema('graphql')
+  const schema = db.user.toGraphQLSchema()
   expect(printSchema(schema)).toMatchInlineSnapshot(`
     "type Query {
       user(where: UserQueryInput): User


### PR DESCRIPTION
This allows to expose the schema directly, to be consumed for example by graphql-codegen - and in consequence by TypeScript (via generated types) or the Apollo Graphql VSCode extension (via an exported introspection schema)

As an example:

```ts
// src/mocks/db.ts
import { factory, primaryKey } from '@mswjs/data'
const db = factory({
  post: {
    id: primaryKey(String),
    name: String,
    title: String,
    author: String,
    content: String,
    status: String,
    created_at: String,
    updated_at: String,
  },
})

export const handlers = db.post.toHandlers('graphql')
export const schema = db.post.toSchema('graphql')
```

```js
// src/mocks/schema.js
require('ts-node/register')
module.exports = require('./db').schema
```

```yml
// codegen.yml
overwrite: true
schema: './src/mocks/schema.js'
documents: 'src/**/*.graphql'
generates:
  src/app/services/graphql.generated.ts:
    plugins:
      - 'typescript'
      - 'typescript-operations'
      - 'typed-document-node'
  .introspection.json:
    plugins:
      - introspection
```