### PR TITLE
handle null value in db isInternalEntity

### DIFF
--- a/src/utils/isInternalEntity.ts
+++ b/src/utils/isInternalEntity.ts
@@ -7,6 +7,7 @@ export function isInternalEntity(
   value: Record<string, any>,
 ): value is InternalEntity<any, any> {
   return (
+    value &&
     InternalEntityProperty.type in value &&
     InternalEntityProperty.primaryKey in value
   )

--- a/test/db/drop.test.ts
+++ b/test/db/drop.test.ts
@@ -36,19 +36,20 @@ test('does nothing when the database is already empty', () => {
   expect(db.user.getAll()).toHaveLength(0)
 })
 
-test('db drop does not care relation dependency', () => {
+test('properly cleans up relational properties', () => {
   const db = factory({
     user: {
       id: primaryKey(identity('abc-123')),
     },
     group: {
-      id: primaryKey(identity('xyz-123')),
-      root: oneOf('user')
+      id: primaryKey(identity('def-456')),
+      owner: oneOf('user')
     }
   })
 
   const user = db.user.create()
-  db.group.create({root: user})
+  db.group.create({ owner: user })
+
   expect(db.user.getAll()).toHaveLength(1)
   expect(db.group.getAll()).toHaveLength(1)
 

--- a/test/db/drop.test.ts
+++ b/test/db/drop.test.ts
@@ -1,4 +1,4 @@
-import { drop, factory, identity, primaryKey } from '@mswjs/data'
+import { drop, factory, identity, primaryKey, oneOf } from '@mswjs/data'
 
 test('drops all records in the database', () => {
   const db = factory({
@@ -34,4 +34,25 @@ test('does nothing when the database is already empty', () => {
 
   drop(db)
   expect(db.user.getAll()).toHaveLength(0)
+})
+
+test('db drop does not care relation dependency', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(identity('abc-123')),
+    },
+    group: {
+      id: primaryKey(identity('xyz-123')),
+      root: oneOf('user')
+    }
+  })
+
+  const user = db.user.create()
+  db.group.create({root: user})
+  expect(db.user.getAll()).toHaveLength(1)
+  expect(db.group.getAll()).toHaveLength(1)
+
+  drop(db)
+  expect(db.user.getAll()).toHaveLength(0)
+  expect(db.group.getAll()).toHaveLength(0)
 })


### PR DESCRIPTION
### Issue

`removeInternalProperties` determines internal properties by looking at the value's type and the value's sub-properties. For example, [here](https://github.com/mswjs/data/blob/aa6ca0a48453faf9cfffe2a53ba927ac847d95c0/src/utils/removeInternalProperties.ts#L25-L28). When the value is `null` for which `typeof null === 'object'` is true, the following exception is thrown.

```
TypeError: Cannot use 'in' operator to search for '__type' in null

       9 |     return (
      10 |     // value &&
    > 11 |     glossary_1.InternalEntityProperty.type in value &&
         |                                            ^
      12 |         glossary_1.InternalEntityProperty.primaryKey in value);
      13 | }
      14 | exports.isInternalEntity = isInternalEntity;

      at Object.isInternalEntity (lib/utils/isInternalEntity.js:11:44)
      at lib/utils/removeInternalProperties.js:38:61
          at Array.map (<anonymous>)
```

It seems that a `null` could happen when `drop` first removes a record that another to-be-removed record references. The newly added test in this PR could fail without the change in `src`.

### Test run

The only failing test is performance test which I believe is not introduced by this change.

```
npm run build && npm test

Summary of all failing tests
 FAIL  test/performance/performance.test.ts (7.818 s)
  ● creates a 1000 records in under 100ms

    expect(received).toBeLessThanOrEqual(expected)

    Expected: <= 350
    Received:    396.801317

      18 |   })
      19 | 
    > 20 |   expect(createPerformance.duration).toBeLessThanOrEqual(350)
         |                                      ^
      21 | })
      22 | 
      23 | test('queries through a 1000 records in under 100ms', async () => {

      at test/performance/performance.test.ts:20:38
      at step (test/performance/performance.test.ts:33:23)
      at Object.next (test/performance/performance.test.ts:14:53)
      at fulfilled (test/performance/performance.test.ts:5:58)


Test Suites: 1 failed, 41 passed, 42 total
Tests:       1 failed, 187 passed, 188 total
Snapshots:   1 passed, 1 total
Time:        17.233 s
```
