### PR TITLE
Supports sorting with the "orderBy" option on ".findMany()"

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ setupWorker(
 - [Strict mode](#strict-mode)
 - [Model relationships](#model-relationships)
 - [Pagination](#pagination)
+- [Sorting](#sorting)
 
 ### Model methods
 
@@ -640,6 +641,100 @@ const secondPage = db.post.findMany({
   // The second page will start from the last post
   // of the `firstPage`.
   cursor: firstPage[firstPage.length - 1].id,
+})
+```
+
+### Sorting
+
+#### Basic sorting
+
+```js
+const db = factory({
+  post: {
+    id: primaryKey(String),
+    title: String,
+  },
+})
+
+// Return first 10 posts in the "Science" category
+// sorted by the post's "title".
+db.post.findMany({
+  where: {
+    category: {
+      equals: 'Science',
+    },
+  },
+  take: 10,
+  orderBy: {
+    title: 'asc',
+  },
+})
+```
+
+> You can use `orderBy` with [pagination](#pagination).
+
+#### Sorting by relational properties
+
+```js
+const db = factory({
+  post: {
+    id: primaryKey(String),
+    title: String,
+    author: oneOf('user')
+  },
+  user: {
+    id: primaryKey(String),
+    firstName: String
+  }
+})
+
+// Return all posts in the "Science" category
+// sorted by the post author's first name.
+db.post.findMany({
+  where: {
+    category: {
+      equals: 'Science'
+    }
+  }
+  orderBy: {
+    author: {
+      firstName: 'asc'
+    }
+  }
+})
+```
+
+#### Sorting by multiple criteria
+
+Provide a list of criteria to sort the query result against.
+
+```js
+db.post.findMany({
+  orderBy: [
+    {
+      title: 'asc',
+    },
+    {
+      views: 'desc',
+    },
+  ],
+})
+```
+
+You can also use a combination of direct and relational properties on a single query:
+
+```js
+db.post.findMany({
+  orderBy: [
+    {
+      title: 'asc',
+    },
+    {
+      author: {
+        firstName: 'asc',
+      },
+    },
+  ],
 })
 ```
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^26.5.5",
     "ts-node": "^9.1.1",
-    "typescript": "^4.2.4"
+    "typescript": "4.3.5"
   },
   "dependencies": {
     "@types/lodash.get": "^4.4.6",

--- a/package.json
+++ b/package.json
@@ -37,11 +37,13 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
+    "@types/lodash.get": "^4.4.6",
     "@types/md5": "^2.3.0",
     "@types/pluralize": "^0.0.29",
     "@types/uuid": "^8.3.0",
     "date-fns": "^2.21.1",
     "graphql": "^15.5.0",
+    "lodash.get": "^4.4.2",
     "md5": "^2.3.0",
     "pluralize": "^8.0.0",
     "strict-event-emitter": "^0.2.0",

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -87,12 +87,12 @@ export interface InternalEntityProperties<ModelName extends KeyType> {
 }
 
 export type Entity<
-  Dictionary extends Record<string, any>,
+  Dictionary extends ModelDictionary,
   ModelName extends keyof Dictionary
 > = Value<Dictionary[ModelName], Dictionary>
 
 export type InternalEntity<
-  Dictionary extends Record<string, any>,
+  Dictionary extends ModelDictionary,
   ModelName extends keyof Dictionary
 > = InternalEntityProperties<ModelName> & Entity<Dictionary, ModelName>
 

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -113,6 +113,23 @@ export type Limit<T extends Record<string, any>> = {
   }
 }
 
+export type RequireExactlyOne<
+  ObjectType,
+  KeysType extends keyof ObjectType = keyof ObjectType
+> = {
+  [Key in KeysType]: Required<Pick<ObjectType, Key>> &
+    Partial<Record<Exclude<KeysType, Key>, never>>
+}[KeysType] &
+  Pick<ObjectType, Exclude<keyof ObjectType, KeysType>>
+
+export type DeepRequireExactlyOne<ObjectType> = RequireExactlyOne<
+  {
+    [K in keyof ObjectType]: ObjectType[K] extends Record<any, any>
+      ? RequireExactlyOne<ObjectType[K]>
+      : ObjectType[K]
+  }
+>
+
 export interface ModelAPI<
   Dictionary extends ModelDictionary,
   ModelName extends keyof Dictionary
@@ -138,7 +155,7 @@ export interface ModelAPI<
    */
   findMany(
     query: WeakQuerySelector<Value<Dictionary[ModelName], Dictionary>> &
-      BulkQueryOptions,
+      BulkQueryOptions<Value<Dictionary[ModelName], Dictionary>>,
   ): Entity<Dictionary, ModelName>[]
   /**
    * Return all entities of the current model.

--- a/src/query/compileQuery.ts
+++ b/src/query/compileQuery.ts
@@ -15,11 +15,11 @@ export function compileQuery<Data extends Record<string, any>>(
 
   return (data: Data): boolean => {
     return Object.entries(query.where)
-      .map<boolean>(([propName, queryChunk]) => {
-        const actualValue = data[propName]
+      .map<boolean>(([property, queryChunk]) => {
+        const actualValue = data[property]
 
         log('executing query chunk', queryChunk, data)
-        log(`actual value for "${propName}"`, actualValue)
+        log('actual value for "%s"', property, actualValue)
 
         if (!queryChunk) {
           return true

--- a/src/query/executeQuery.ts
+++ b/src/query/executeQuery.ts
@@ -13,6 +13,7 @@ import {
 import * as iteratorUtils from '../utils/iteratorUtils'
 import { paginateResults } from './paginateResults'
 import { Database } from '../db/Database'
+import { sortResults } from './sortResults'
 
 const log = debug('executeQuery')
 
@@ -37,7 +38,7 @@ function queryByPrimaryKey(
 export function executeQuery(
   modelName: string,
   primaryKey: PrimaryKeyType,
-  query: WeakQuerySelector<any> & BulkQueryOptions,
+  query: WeakQuerySelector<any> & BulkQueryOptions<any>,
   db: Database<any>,
 ): InternalEntity<any, any>[] {
   log(`${JSON.stringify(query)} on "${modelName}"`)
@@ -65,6 +66,10 @@ export function executeQuery(
     `resolved query "${JSON.stringify(query)}" on "${modelName}" to`,
     resultJson,
   )
+
+  if (query.orderBy) {
+    sortResults(query.orderBy, resultJson)
+  }
 
   const paginatedResults = paginateResults(query, resultJson)
   log('paginated query results', paginatedResults)

--- a/src/query/paginateResults.ts
+++ b/src/query/paginateResults.ts
@@ -6,7 +6,7 @@ function getEndIndex(start: number, end?: number) {
 }
 
 export function paginateResults(
-  query: WeakQuerySelector<any> & BulkQueryOptions,
+  query: WeakQuerySelector<any> & BulkQueryOptions<any>,
   data: InternalEntity<any, any>[],
 ): InternalEntity<any, any>[] {
   if (query.cursor) {

--- a/src/query/queryTypes.ts
+++ b/src/query/queryTypes.ts
@@ -1,4 +1,9 @@
-import { PrimaryKeyType, Value } from '../glossary'
+import {
+  BaseTypes,
+  DeepRequireExactlyOne,
+  PrimaryKeyType,
+  Value,
+} from '../glossary'
 
 export interface QuerySelector<EntityType extends Record<string, any>> {
   strict?: boolean
@@ -17,21 +22,35 @@ export interface WeakQuerySelectorWhere<KeyType extends PrimaryKeyType> {
   [key: string]: Partial<GetQueryFor<KeyType>>
 }
 
-interface BulkQueryBaseOptions {
+export type SortDirection = 'asc' | 'desc'
+export type OrderBy<EntityType> = DeepRequireExactlyOne<
+  {
+    [K in keyof EntityType]?: EntityType[K] extends BaseTypes
+      ? SortDirection
+      : OrderBy<EntityType[K]>
+  }
+>
+
+export interface BulkQueryBaseOptions<EntityType extends Record<string, any>> {
   take?: number
+  orderBy?: OrderBy<EntityType> | OrderBy<EntityType>[]
 }
 
-interface BulkQueryOffsetOptions extends BulkQueryBaseOptions {
+interface BulkQueryOffsetOptions<EntityType>
+  extends BulkQueryBaseOptions<EntityType> {
   skip?: number
   cursor?: never
 }
 
-interface BulkQueryCursorOptions extends BulkQueryBaseOptions {
+interface BulkQueryCursorOptions<EntityType>
+  extends BulkQueryBaseOptions<EntityType> {
   skip?: never
   cursor: PrimaryKeyType | null
 }
 
-export type BulkQueryOptions = BulkQueryOffsetOptions | BulkQueryCursorOptions
+export type BulkQueryOptions<EntityType> =
+  | BulkQueryOffsetOptions<EntityType>
+  | BulkQueryCursorOptions<EntityType>
 
 export type ComparatorFn<ExpectedType extends any, ActualType extends any> = (
   expected: ExpectedType,

--- a/src/query/sortResults.ts
+++ b/src/query/sortResults.ts
@@ -47,6 +47,9 @@ function flattenSortCriteria<EntityType extends Entity<any, any>>(
   }, [])
 }
 
+/**
+ * Sorts the given list of entities by a certain criteria.
+ */
 export function sortResults<EntityType extends Entity<any, any>>(
   orderBy: OrderBy<EntityType> | OrderBy<EntityType>[],
   data: InternalEntity<any, any>[],

--- a/src/query/sortResults.ts
+++ b/src/query/sortResults.ts
@@ -1,0 +1,89 @@
+import debug from 'debug'
+import get from 'lodash.get'
+import { Entity, InternalEntity } from 'src/glossary'
+import { OrderBy, SortDirection } from './queryTypes'
+
+const log = debug('sortResults')
+
+type FlatSortCriteria = [string[], SortDirection]
+
+function warnOnIneffectiveSortingKeys(sortCriteria: Record<string, any>): void {
+  const [mainCriteria, ...siblings] = Object.keys(sortCriteria)
+
+  if (siblings.length > 0) {
+    console.warn(
+      'Sorting by "%s" has no effect: already sorted by "%s".',
+      siblings.join(','),
+      mainCriteria,
+    )
+  }
+}
+
+function flattenSortCriteria<EntityType extends Entity<any, any>>(
+  orderBy: OrderBy<EntityType>[],
+  propertyPath: string[] = [],
+): FlatSortCriteria[] {
+  log('flattenSortCriteria:', orderBy, propertyPath)
+
+  return orderBy.reduce<FlatSortCriteria[]>((criteria, properties) => {
+    warnOnIneffectiveSortingKeys(properties)
+
+    // Multiple properties in a single criteria object are forbidden.
+    // Use the list of criteria objects for multi-criteria sort.
+    const property = Object.keys(properties)[0] as keyof OrderBy<EntityType>
+    const sortDirection = properties[property]!
+    const path = propertyPath.concat(property.toString())
+    log({ property, sortDirection, path })
+
+    // Recursively flatten order criteria when referencing
+    // relational properties.
+    const newCriteria =
+      typeof sortDirection === 'object'
+        ? flattenSortCriteria([sortDirection], path)
+        : ([[path, sortDirection]] as FlatSortCriteria[])
+
+    log('pushing new criteria:', newCriteria)
+    return criteria.concat(newCriteria)
+  }, [])
+}
+
+export function sortResults<EntityType extends Entity<any, any>>(
+  orderBy: OrderBy<EntityType> | OrderBy<EntityType>[],
+  data: InternalEntity<any, any>[],
+): void {
+  log('sorting data:', data)
+  log('order by:', orderBy)
+
+  const criteriaList = ([] as OrderBy<EntityType>[]).concat(orderBy)
+  log('criteria list:', criteriaList)
+
+  const criteria = flattenSortCriteria(criteriaList)
+  log('flattened criteria:', JSON.stringify(criteria))
+
+  data.sort((left, right) => {
+    for (const [path, sortDirection] of criteria) {
+      const leftValue = get(left, path)
+      const rightValue = get(right, path)
+
+      log(
+        'comparing value at "%s" (%s): "%s" / "%s"',
+        path,
+        sortDirection,
+        leftValue,
+        rightValue,
+      )
+
+      if (leftValue > rightValue) {
+        return sortDirection === 'asc' ? 1 : -1
+      }
+
+      if (leftValue < rightValue) {
+        return sortDirection === 'asc' ? -1 : 1
+      }
+    }
+
+    return 0
+  })
+
+  log('sorted results:\n', data)
+}

--- a/src/utils/removeInternalProperties.ts
+++ b/src/utils/removeInternalProperties.ts
@@ -1,48 +1,64 @@
-import { InternalEntity, InternalEntityProperty, Entity } from '../glossary'
+import {
+  InternalEntity,
+  InternalEntityProperty,
+  Entity,
+  ModelDictionary,
+  Value,
+} from '../glossary'
 import { isInternalEntity } from './isInternalEntity'
+
+function isOneOfRelation<
+  Dictionary extends ModelDictionary,
+  ModelName extends keyof Dictionary
+>(
+  value: Value<Dictionary[ModelName], Dictionary>,
+): value is InternalEntity<Dictionary, ModelName> {
+  return typeof value === 'object' && isInternalEntity(value)
+}
+
+function isManyOfRelation(
+  value: Value<any, any>,
+): value is Array<InternalEntity<any, any>> {
+  return Array.isArray(value) && value.every(isInternalEntity)
+}
 
 /**
  * Removes internal properties from the given entity.
  */
 export function removeInternalProperties<
-  Dictionary extends Record<string, any>,
+  Dictionary extends ModelDictionary,
   ModelName extends keyof Dictionary
 >(
   entity: InternalEntity<Dictionary, ModelName>,
 ): Entity<Dictionary, ModelName> {
-  return (
-    Object.entries(entity)
-      // Remove internal entity properties.
-      .filter(([property, value]) => {
-        if (
-          property !== InternalEntityProperty.type &&
-          property !== InternalEntityProperty.primaryKey
-        ) {
-          return [property, value]
-        }
-      })
-      .map<[string, Entity<Dictionary, ModelName>]>(([property, value]) => {
-        // Remove internal properties of a "oneOf" relation.
-        if (typeof value === 'object' && isInternalEntity(value)) {
-          return [property, removeInternalProperties(value)]
-        }
-
-        // Remove internal properties of a "manyOf" relation.
-        if (Array.isArray(value)) {
-          const publicEntity = value.map((relationalEntity: any) => {
-            return isInternalEntity(relationalEntity)
-              ? removeInternalProperties(relationalEntity)
-              : relationalEntity
-          })
-
-          return [property, publicEntity]
-        }
-
-        return [property, value]
-      })
-      .reduce<any>((entity, [property, value]) => {
-        entity[property] = value
+  return Object.entries(entity).reduce<Entity<any, ModelName>>(
+    (entity, [property, value]) => {
+      // Remove the internal entity properties.
+      if (
+        property === InternalEntityProperty.type ||
+        property === InternalEntityProperty.primaryKey
+      ) {
         return entity
-      }, {})
+      }
+
+      // Remove the internal properties of a "oneOf" relation.
+      if (isOneOfRelation(value)) {
+        const relationalEntity = removeInternalProperties(value)
+        entity[property] = relationalEntity
+        return entity
+      }
+
+      // Remove the internal properties of a "manyOf" relation.
+      if (isManyOfRelation(value)) {
+        const relationalEntityList = value.map(removeInternalProperties)
+        entity[property] = relationalEntityList
+        return entity
+      }
+
+      // Otherwise dealing with a base type value, preserving.
+      entity[property] = value
+      return entity
+    },
+    {},
   )
 }

--- a/test/query/pagination.test.ts
+++ b/test/query/pagination.test.ts
@@ -1,5 +1,5 @@
 import { datatype } from 'faker'
-import { factory, primaryKey } from '@mswjs/data'
+import { factory, primaryKey, oneOf } from '@mswjs/data'
 
 test('supports offset-based pagination', () => {
   const db = factory({
@@ -98,4 +98,237 @@ test('returns an empty list given invalid cursor', () => {
     cursor: 'abc-invalid-cursor',
   })
   expect(firstPage).toEqual([])
+})
+
+test('supports single-criteria sorting in the paginated results', () => {
+  const db = factory({
+    book: {
+      id: primaryKey(datatype.uuid),
+      title: String,
+      publishedYear: Number,
+    },
+  })
+
+  db.book.create({ title: 'B', publishedYear: 1875 })
+  db.book.create({ title: 'C', publishedYear: 2004 })
+  db.book.create({ title: 'A', publishedYear: 2021 })
+  db.book.create({ title: 'D', publishedYear: 2006 })
+
+  const firstPage = db.book.findMany({
+    where: {
+      publishedYear: { gte: 1990 },
+    },
+    take: 2,
+    orderBy: { title: 'asc' },
+  })
+  const firstPageTitles = firstPage.map((book) => book.title)
+  expect(firstPageTitles).toEqual(['A', 'C'])
+
+  const secondPage = db.book.findMany({
+    where: {
+      publishedYear: { gte: 1990 },
+    },
+    skip: 2,
+    take: 2,
+    orderBy: {
+      title: 'asc',
+    },
+  })
+  const secondPageTitles = secondPage.map((book) => book.title)
+  expect(secondPageTitles).toEqual(['D'])
+})
+
+test('supports multi-criteria sorting in the paginated results', () => {
+  const db = factory({
+    book: {
+      id: primaryKey(datatype.uuid),
+      title: String,
+      publishedYear: Number,
+    },
+  })
+
+  db.book.create({ title: 'A', publishedYear: 1875 })
+  db.book.create({ title: 'C', publishedYear: 2004 })
+  db.book.create({ title: 'A', publishedYear: 2021 })
+  db.book.create({ title: 'D', publishedYear: 2006 })
+
+  const firstPage = db.book.findMany({
+    take: 2,
+    orderBy: [
+      {
+        title: 'asc',
+      },
+      {
+        publishedYear: 'desc',
+      },
+    ],
+  })
+  const firstPageBooks = firstPage.map((book) => [
+    book.title,
+    book.publishedYear,
+  ])
+  expect(firstPageBooks).toEqual([
+    ['A', 2021],
+    ['A', 1875],
+  ])
+
+  const secondPage = db.book.findMany({
+    skip: 2,
+    take: 2,
+    orderBy: [
+      {
+        title: 'asc',
+      },
+      {
+        publishedYear: 'desc',
+      },
+    ],
+  })
+  const secondPageBooks = secondPage.map((book) => book.title)
+  expect(secondPageBooks).toEqual(['C', 'D'])
+})
+
+test('supports single-criteria sorting by relational property in the paginated results', () => {
+  const db = factory({
+    book: {
+      id: primaryKey(datatype.uuid),
+      title: String,
+      author: oneOf('author'),
+    },
+    author: {
+      id: primaryKey(datatype.uuid),
+      firstName: String,
+    },
+  })
+
+  const john = db.author.create({ firstName: 'John' })
+  const george = db.author.create({ firstName: 'George' })
+  const nelson = db.author.create({ firstName: 'Nelson' })
+  db.book.create({ title: 'A', author: john })
+  db.book.create({ title: 'B', author: george })
+  db.book.create({ title: 'C', author: nelson })
+
+  const firstPage = db.book.findMany({
+    take: 2,
+    orderBy: {
+      author: {
+        firstName: 'asc',
+      },
+    },
+  })
+  const firstPageBooks = firstPage.map((book) => book.title)
+  const firstPageAuthors = firstPage.map((book) => book.author.firstName)
+  expect(firstPageBooks).toEqual(['B', 'A'])
+  expect(firstPageAuthors).toEqual(['George', 'John'])
+})
+
+test('supports multi-criteria sorting by relational property in the paginated results', () => {
+  const db = factory({
+    book: {
+      id: primaryKey(datatype.uuid),
+      title: String,
+      author: oneOf('author'),
+    },
+    author: {
+      id: primaryKey(datatype.uuid),
+      firstName: String,
+      bornAt: () => new Date(),
+    },
+  })
+
+  const john = db.author.create({
+    firstName: 'John',
+    bornAt: new Date('1980-01-30'),
+  })
+  const george = db.author.create({
+    firstName: 'George',
+    bornAt: new Date('1990-12-08'),
+  })
+  const nelson = db.author.create({
+    firstName: 'Nelson',
+    bornAt: new Date('1986-09-09'),
+  })
+  db.book.create({ title: 'A', author: john })
+  db.book.create({ title: 'B', author: george })
+  db.book.create({ title: 'C', author: nelson })
+
+  const firstPage = db.book.findMany({
+    take: 2,
+    orderBy: [
+      {
+        author: {
+          firstName: 'asc',
+        },
+      },
+      {
+        author: {
+          bornAt: 'desc',
+        },
+      },
+    ],
+  })
+  const firstPageBooks = firstPage.map((book) => book.title)
+  const firstPageAuthors = firstPage.map((book) => book.author.firstName)
+  expect(firstPageBooks).toEqual(['B', 'A'])
+  expect(firstPageAuthors).toEqual(['George', 'John'])
+
+  const secondPage = db.book.findMany({
+    skip: 2,
+    take: 2,
+    orderBy: [
+      {
+        author: {
+          firstName: 'asc',
+        },
+      },
+      {
+        author: {
+          bornAt: 'desc',
+        },
+      },
+    ],
+  })
+  const secondPageBooks = secondPage.map((book) => book.title)
+  const secondPageAuthors = secondPage.map((book) => book.author.firstName)
+  expect(secondPageBooks).toEqual(['C'])
+  expect(secondPageAuthors).toEqual(['Nelson'])
+})
+
+test('supports sorting by both direct and relational properties in the paginated results', () => {
+  const db = factory({
+    book: {
+      id: primaryKey(datatype.uuid),
+      title: String,
+      author: oneOf('author'),
+    },
+    author: {
+      id: primaryKey(datatype.uuid),
+      firstName: String,
+    },
+  })
+
+  const john = db.author.create({ firstName: 'John' })
+  const george = db.author.create({ firstName: 'George' })
+  const nelson = db.author.create({ firstName: 'Nelson' })
+  db.book.create({ title: 'A', author: john })
+  db.book.create({ title: 'B', author: george })
+  db.book.create({ title: 'A', author: nelson })
+
+  const firstPage = db.book.findMany({
+    take: 2,
+    orderBy: [
+      {
+        title: 'asc',
+      },
+      {
+        author: {
+          firstName: 'asc',
+        },
+      },
+    ],
+  })
+  const firstPageBooks = firstPage.map((book) => book.title)
+  const firstPageAuthors = firstPage.map((book) => book.author.firstName)
+  expect(firstPageBooks).toEqual(['A', 'A'])
+  expect(firstPageAuthors).toEqual(['John', 'Nelson'])
 })

--- a/test/typings/typings.ts
+++ b/test/typings/typings.ts
@@ -232,8 +232,8 @@ db.user.findMany({
     },
     {
       country: {
-        // @ts-expect-error Cannot specify more than 1 sorting key.
         id: 'desc',
+        // @ts-expect-error Cannot specify more than 1 sorting key.
         name: 'asc',
       },
     },

--- a/test/typings/typings.ts
+++ b/test/typings/typings.ts
@@ -4,10 +4,12 @@ const db = factory({
   user: {
     id: primaryKey(String),
     firstName: String,
+    createdAt: () => new Date(),
     country: oneOf('country'),
   },
   country: {
-    name: primaryKey(String),
+    id: primaryKey(String),
+    name: String,
   },
   post: {
     id: primaryKey(String),
@@ -98,4 +100,142 @@ db.user.getAll().map((user) => {
 
   // @ts-expect-error Unknown property "foo" on the "user" model.
   user.foo
+})
+
+/**
+ * Sorting.
+ */
+db.user.findMany({
+  orderBy: {
+    firstName: 'asc',
+  },
+})
+
+db.user.findMany({
+  orderBy: {
+    createdAt: 'asc',
+  },
+})
+
+db.user.findMany({
+  orderBy: [
+    {
+      id: 'asc',
+    },
+    {
+      firstName: 'desc',
+    },
+  ],
+})
+
+db.user.findMany({
+  orderBy: {
+    country: {
+      name: 'asc',
+    },
+  },
+})
+
+db.user.findMany({
+  orderBy: [
+    {
+      firstName: 'desc',
+    },
+    {
+      country: {
+        name: 'asc',
+      },
+    },
+  ],
+})
+
+db.user.findMany({
+  orderBy: [
+    {
+      country: {
+        id: 'asc',
+      },
+    },
+    {
+      country: {
+        name: 'desc',
+      },
+    },
+  ],
+})
+
+db.user.findMany({
+  // @ts-expect-error Unknown sort criteria.
+  orderBy: {
+    firstName: 'acs',
+  },
+})
+
+db.user.findMany({
+  orderBy: [
+    {
+      // @ts-expect-error Unknown sort criteria.
+      firstName: 'acs',
+    },
+  ],
+})
+
+db.user.findMany({
+  orderBy: [
+    {
+      country: {
+        // @ts-expect-error Unknown sort criteria.
+        name: 'unknown',
+      },
+    },
+  ],
+})
+
+db.user.findMany({
+  orderBy: {
+    // @ts-expect-error Unknown property "foo" on the "user" model.
+    foo: 'asc',
+  },
+})
+
+db.user.findMany({
+  orderBy: [
+    {
+      // @ts-expect-error Unknown property "foo" on the "user" model.
+      foo: 'asc',
+    },
+  ],
+})
+
+db.user.findMany({
+  // @ts-expect-error Cannot specify more than 1 sorting key.
+  orderBy: {
+    id: 'asc',
+    firstName: 'desc',
+  },
+})
+
+db.user.findMany({
+  orderBy: [
+    // @ts-expect-error Cannot specify more than 1 sorting key.
+    {
+      id: 'asc',
+      firstName: 'desc',
+    },
+  ],
+})
+
+db.user.findMany({
+  orderBy: [
+    {
+      id: 'asc',
+    },
+    {
+      country: {
+        // @ts-expect-error Cannot specify more than 1 sorting key.
+        id: 'desc',
+        name: 'asc',
+      },
+    },
+  ],
 })

--- a/test/utils/removeInternalProperties.test.ts
+++ b/test/utils/removeInternalProperties.test.ts
@@ -21,12 +21,14 @@ it('removes internal properties from an entity with relations', () => {
     __primaryKey: 'id',
     id: 'abc-123',
     firstName: 'John',
+    // "oneOf" relation.
     address: {
       __type: 'address',
       __primaryKey: 'id',
       id: 'addr-123',
       street: 'Broadway',
     },
+    // "manyOf" relation.
     contacts: [
       {
         __type: 'contact',
@@ -57,7 +59,7 @@ it('removes internal properties from an entity with relations', () => {
   })
 })
 
-it('preserves custom properties starting with a leading "__"', () => {
+it('preserves custom properties starting with the double underscore', () => {
   const user: InternalEntity<any, any> = {
     __type: 'user',
     __primaryKey: 'id',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "moduleResolution": "node",
     "downlevelIteration": true,
     "esModuleInterop": true,
+    "noImplicitAny": true,
     "baseUrl": ".",
     "paths": {
       "@mswjs/data": ["./lib"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -664,6 +664,18 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
 
+"@types/lodash.get@^4.4.6":
+  version "4.4.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.get/-/lodash.get-4.4.6.tgz#0c7ac56243dae0f9f09ab6f75b29471e2e777240"
+  integrity sha512-E6zzjR3GtNig8UJG/yodBeJeIOtgPkMgsLjDU3CbgCAPC++vJ0eCMnJhVpRZb/ENqEFlov1+3K9TKtY4UdWKtQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.170"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.170.tgz#0d67711d4bf7f4ca5147e9091b847479b87925d6"
+  integrity sha512-bpcvu/MKHHeYX+qeEN8GE7DIravODWdACVA1ctevD8CN24RhPZIKMn9ntfAsrvLfSX3cR5RrBKAbYm9bGs0A+Q==
+
 "@types/md5@^2.3.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@types/md5/-/md5-2.3.0.tgz#3b6a623091160f4dc75be3173e25f2110dc3fa1f"
@@ -3279,6 +3291,11 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4852,10 +4852,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.2.4:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
-  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
+typescript@4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
## GitHub

- Closes #102 

## Changes

It is now possible to sort query results of the `.findMany()` method using the `orderBy` property on the query:

```js
db.post.findMany({
  where: {
    category: {
      equals: 'Science',
    },
  },
  take: 10,
  orderBy: {
    title: 'asc',
  },
})
```

Provides support for:

- Basic sorting by direct properties.
- Sorting by multiple criteria.
- Sorting by relational properties. 

## Restrictions

- Only 1 known entity key can be specified in the sort criteria object. Use the list of criteria for multi-criteria sort. 

## Roadmap

- [x] Restrict multiple keys in the `orderBy` criteria object.
- [x] Improve the warning when using multiple keys in the `orderBy` criteria object (for non-TS users). 
- [x] Add typings tests.