### PR TITLE
Specifies the "latest" version of "msw" as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "debug": "^4.3.1",
     "faker": "^5.5.3",
     "jest": "^26.6.0",
-    "msw": "^0.33.0",
+    "msw": "latest",
     "node-fetch": "^2.6.1",
     "page-with": "^0.3.5",
     "prettier": "^2.2.1",
@@ -48,6 +48,6 @@
     "uuid": "^8.3.1"
   },
   "optionalDependencies": {
-    "msw": "^0.33.0"
+    "msw": "latest"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3483,7 +3483,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-msw@^0.33.0:
+msw@latest:
   version "0.33.0"
   resolved "https://registry.yarnpkg.com/msw/-/msw-0.33.0.tgz#6a842dd17a6e8a2aff176106fb18b50a7b37ab8e"
   integrity sha512-lX0mBSE+kgXYMiqyjaYM+2kfxPg2ywbhZjPDwHk5bN/MqoEvGcj6cpL0j1OgLSitN1ve8F0ePCSrk2jhITRubw==


### PR DESCRIPTION
## GitHub

- Fixes https://github.com/mswjs/msw/issues/832
- Originated from #106 

## Changes

- The `msw` package is not pinned to the `latest` published version tag. This is rather permissive, but it should encourage the users to migrate to the latest version of `msw` and also rid this package from bumping the `msw` version on each minor release.

As #106 illustrates, there may be issues related to the application and `@mswjs/data` installing and using different versions of `msw`. Pinning the version to be the latest means that the data package always relies on the latest version and demands from the application to do so as well. 

Note that patch releases never contain breaking changes, so it should be safe to be ahead/behind in patch versions. 