### PR TITLE
isInternalEntity: Assert the value is an object

### DIFF
--- a/src/utils/isInternalEntity.ts
+++ b/src/utils/isInternalEntity.ts
@@ -1,13 +1,14 @@
 import { InternalEntity, InternalEntityProperty } from '../glossary'
+import { isObject } from './isObject'
 
 /**
- * Determines if the given object is an internal entity.
+ * Returns true if the given value is an internal entity object.
  */
 export function isInternalEntity(
   value: Record<string, any>,
 ): value is InternalEntity<any, any> {
   return (
-    value &&
+    isObject(value) &&
     InternalEntityProperty.type in value &&
     InternalEntityProperty.primaryKey in value
   )

--- a/src/utils/isObject.ts
+++ b/src/utils/isObject.ts
@@ -1,0 +1,6 @@
+/**
+ * Returns true if the given value is a plain Object.
+ */
+export function isObject(value: any): value is Record<string, any> {
+  return value != null && typeof value === 'object' && !Array.isArray(value)
+}

--- a/src/utils/removeInternalProperties.ts
+++ b/src/utils/removeInternalProperties.ts
@@ -13,7 +13,7 @@ function isOneOfRelation<
 >(
   value: Value<Dictionary[ModelName], Dictionary>,
 ): value is InternalEntity<Dictionary, ModelName> {
-  return typeof value === 'object' && isInternalEntity(value)
+  return isInternalEntity(value)
 }
 
 function isManyOfRelation(

--- a/test/utils/isObject.test.ts
+++ b/test/utils/isObject.test.ts
@@ -1,0 +1,20 @@
+import { isObject } from '../../src/utils/isObject'
+
+it('returns true given an empty object', () => {
+  expect(isObject({})).toEqual(true)
+})
+
+it('returns true given an object with values', () => {
+  expect(isObject({ a: 1, b: ['foo'] })).toEqual(true)
+})
+
+it('returns false given falsy values', () => {
+  expect(isObject(undefined)).toEqual(false)
+  expect(isObject(null)).toEqual(false)
+  expect(isObject(false)).toEqual(false)
+})
+
+it('returns false given an array', () => {
+  expect(isObject([])).toEqual(false)
+  expect(isObject([{ a: 1 }])).toEqual(false)
+})


### PR DESCRIPTION
## GitHub

- Fixes #94 
- A prerequisite for #98, #113 

## Changes

- Asserts that the given value is an object during the `isInternalEntity` check.

This prevents the `isInternalEntity` check to throw an exception when handling non-object types (still possible on runtime with the nested properties in model declarations).

```
TypeError: Cannot use 'in' operator to search for '__type' in "some value"
```