### PR TITLE
fix(Relation): support updating relation without initial value

### DIFF
--- a/src/relations/Relation.ts
+++ b/src/relations/Relation.ts
@@ -114,13 +114,11 @@ export class Relation<
   /**
    * Applies the relation to the given entity.
    * Creates a connection between the relation's target and source.
-   * Defines a proxy property to resolve the relation value
-   * whenever refenreced at the given path on the entity.
+   * Does not define the proxy property getter.
    */
   public apply(
     entity: Entity<any, any>,
     propertyPath: string,
-    refs: ReferenceType,
     dictionary: Dictionary,
     db: Database<Dictionary>,
   ) {
@@ -148,8 +146,6 @@ export class Relation<
       this.target.modelName,
     )
     this.target.primaryKey = targetPrimaryKey
-
-    this.resolveWith(entity, refs)
   }
 
   /**
@@ -159,6 +155,13 @@ export class Relation<
     entity: Entity<Dictionary, string>,
     refs: ReferenceType,
   ): void {
+    invariant(
+      this.source,
+      'Failed to resolve a "%s" relational property to "%s": relation has not been applied.',
+      this.kind,
+      this.target.modelName,
+    )
+
     log(
       'resolving a "%s" relational property to "%s" on "%s.%s" ("%s")',
       this.kind,
@@ -171,7 +174,7 @@ export class Relation<
 
     invariant(
       this.target.primaryKey,
-      'Failed to define a "%s" relation to "%s" on "%s": relation is not applied to a dictionary.',
+      'Failed to define a "%s" relation to "%s" on "%s": referenced target model has no primary key set.',
       this.kind,
       this.source.propertyPath,
       this.source.modelName,


### PR DESCRIPTION
## GitHub

- Fixes #137

## Root cause

The issue occurred because relation was applied only when parsing the model. So if it wasn't provided an initial value, the entire application was skipped:

https://github.com/mswjs/data/blob/cf67f57185074ee12ca77a2ebbd089c8df7417c1/src/model/defineRelationalProperties.ts#L24-L27

This meant that when you update a parent entity, its relational property (`Relation` instance) didn't have `source` set at all, throwing an exception. This is not correct, even relational properties without initial values must be applied. 

## Changes

- Relation is no longer resolved when applied.
- _All_ relations are applied when defining relational properties, but only those with initial values are resolved. This sets the necessary `target`/`source` properties on the `Relation` instance but does _not_ define a proxy getter property. 
- Rewrites relation test to assert exact data structures (makes tests more precise). 