### PR TITLE
Add support for null property values

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ db.user.toHandlers('graphql', 'https://example.com/graphql')
 
 ### Nullable properties
 
-You may use the `nullable` function to define properties that can be null:
+By default, all model properties are non-nullable. You can use the `nullable` function to mark a property as nullable:
 
 ```js
 import { factory, primaryKey, nullable } from '@mswjs/data'
@@ -345,19 +345,19 @@ import { factory, primaryKey, nullable } from '@mswjs/data'
 const db = factory({
   user: {
     id: primaryKey(String),
-    name: nullable(String),
+    firstName: String,
+    // "user.age" is a nullable property.
     age: nullable(Number),
   },
 })
 
-// age can now be set as null
 db.user.create({
   id: 'user-1',
-  name: 'John',
+  firstName: 'John',
+  // Nullable properties can be explicit null as the initial value.
   age: null,
 })
 
-// we can update nullable fields to null, or their underlying type later
 db.user.update({
   where: {
     id: {
@@ -365,13 +365,15 @@ db.user.update({
     },
   },
   data: {
-    age: 23,
-    name: null
+    // Nullable properties can be updated to null.
+    age: null,
   },
 })
 ```
 
-When using Typescript you can manually set the type of the property when it is
+> You can define [Nullable relationships](#nullable-relationships) in the same manner.
+
+When using Typescript, you can manually set the type of the property when it is
 not possible to infer it from the factory function, such as when you want the
 property to default to null:
 
@@ -399,7 +401,7 @@ const db = factory({
     address: {
       billing: {
         street: String,
-        city: nullable(String)
+        city: nullable(String),
       },
     },
   },
@@ -582,7 +584,7 @@ const karl = db.user.create({ invitation })
 #### Nullable relationships
 
 Both `oneOf` and `manyOf` relationships may be passed to `nullable` to allow
-setting the relation to null.
+instantiating and updating that relation to null.
 
 ```js
 import { factory, primaryKey, oneOf, nullable } from '@mswjs/data'
@@ -600,10 +602,10 @@ const db = factory({
 
 const invitation = db.invitation.create()
 
+// Nullable relationships are instantiated with null.
 const john = db.user.create({ invitation }) // john.friends === null
 const kate = db.user.create({ friends: [john] }) // kate.invitation === null
 
-// this makes it possible to update the relationships to null
 db.user.updateMany({
   where: {
     id: {
@@ -611,8 +613,9 @@ db.user.updateMany({
     },
   },
   data: {
+    // Nullable relationships can be updated to null.
     invitation: null,
-    friends: null
+    friends: null,
   },
 })
 ```
@@ -797,12 +800,12 @@ const db = factory({
   post: {
     id: primaryKey(String),
     title: String,
-    author: oneOf('user')
+    author: oneOf('user'),
   },
   user: {
     id: primaryKey(String),
-    firstName: String
-  }
+    firstName: String,
+  },
 })
 
 // Return all posts in the "Science" category
@@ -810,14 +813,14 @@ const db = factory({
 db.post.findMany({
   where: {
     category: {
-      equals: 'Science'
-    }
+      equals: 'Science',
+    },
   },
   orderBy: {
     author: {
-      firstName: 'asc'
-    }
-  }
+      firstName: 'asc',
+    },
+  },
 })
 ```
 

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -19,9 +19,9 @@ export type ModelValueTypeGetter = () => ModelValueType
 export type ModelDefinition = Record<string, ModelDefinitionValue>
 
 export type ModelDefinitionValue =
+  | PrimaryKey<any>
   | ModelValueTypeGetter
   | NullableProperty<any>
-  | PrimaryKey<any>
   | OneOf<any, boolean>
   | ManyOf<any, boolean>
   | NestedModelDefinition
@@ -171,9 +171,9 @@ export type UpdateManyValue<
   | {
       [Key in keyof Target]?: Target[Key] extends PrimaryKey
         ? (
-            prevValue: ReturnType<Target[Key]['getValue']>,
+            prevValue: ReturnType<Target[Key]['getPrimaryKeyValue']>,
             entity: Value<Target, Dictionary>,
-          ) => ReturnType<Target[Key]['getValue']>
+          ) => ReturnType<Target[Key]['getPrimaryKeyValue']>
         : Target[Key] extends ModelValueTypeGetter
         ? (
             prevValue: ReturnType<Target[Key]>,
@@ -191,8 +191,8 @@ export type Value<
   Target extends AnyObject,
   Dictionary extends ModelDictionary,
 > = {
-  [Key in keyof Target]: Target[Key] extends PrimaryKey
-    ? ReturnType<Target[Key]['getValue']>
+  [Key in keyof Target]: Target[Key] extends PrimaryKey<any>
+    ? ReturnType<Target[Key]['getPrimaryKeyValue']>
     : // Extract underlying value type of nullable properties
     Target[Key] extends NullableProperty<any>
     ? ReturnType<Target[Key]['getValue']>

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -22,16 +22,16 @@ export type ModelDefinitionValue =
   | ModelValueTypeGetter
   | NullableProperty<any>
   | PrimaryKey<any>
-  | OneOf<any, any>
-  | ManyOf<any, any>
+  | OneOf<any, boolean>
+  | ManyOf<any, boolean>
   | NestedModelDefinition
 
 export type NestedModelDefinition = {
   [propertyName: string]:
     | ModelValueTypeGetter
     | NullableProperty<any>
-    | OneOf<any, any>
-    | ManyOf<any, any>
+    | OneOf<any, boolean>
+    | ManyOf<any, boolean>
     | NestedModelDefinition
 }
 
@@ -191,7 +191,7 @@ export type Value<
   Target extends AnyObject,
   Dictionary extends ModelDictionary,
 > = {
-  [Key in keyof Target]: Target[Key] extends PrimaryKey<any>
+  [Key in keyof Target]: Target[Key] extends PrimaryKey
     ? ReturnType<Target[Key]['getValue']>
     : // Extract underlying value type of nullable properties
     Target[Key] extends NullableProperty<any>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { factory } from './factory'
 export { primaryKey } from './primaryKey'
+export { nullable } from './nullable';
 export { oneOf } from './relations/oneOf'
 export { manyOf } from './relations/manyOf'
 export { drop } from './db/drop'

--- a/src/model/createModel.ts
+++ b/src/model/createModel.ts
@@ -62,7 +62,7 @@ export function createModel<
         set(
           properties,
           propertyName,
-          initialValue || propertyDefinition.getValue(),
+          initialValue || propertyDefinition.getPrimaryKeyValue(),
         )
         return properties
       }

--- a/src/model/createModel.ts
+++ b/src/model/createModel.ts
@@ -1,4 +1,5 @@
 import { debug } from 'debug'
+import { invariant } from 'outvariant'
 import get from 'lodash/get'
 import set from 'lodash/set'
 import isFunction from 'lodash/isFunction'
@@ -75,6 +76,13 @@ export function createModel<
         set(properties, propertyName, value)
         return properties
       }
+
+      invariant(
+        initialValue !== null,
+        'Failed to create a "%s" entity: a non-nullable property "%s" cannot be instantiated with null. Use the "nullable" function when defining this property to support nullable value.',
+        modelName,
+        propertyName.join('.'),
+      )
 
       if (isModelValueType(initialValue)) {
         log(

--- a/src/model/createModel.ts
+++ b/src/model/createModel.ts
@@ -16,6 +16,8 @@ import { ParsedModelDefinition } from './parseModelDefinition'
 import { defineRelationalProperties } from './defineRelationalProperties'
 import { PrimaryKey } from '../primaryKey'
 import { Relation } from '../relations/Relation'
+import { NullableProperty } from '../nullable'
+import { isModelValueType } from '../utils/isModelValueType'
 
 const log = debug('createModel')
 
@@ -64,14 +66,17 @@ export function createModel<
         return properties
       }
 
-      if (
-        typeof initialValue === 'string' ||
-        typeof initialValue === 'number' ||
-        typeof initialValue === 'boolean' ||
-        // @ts-ignore
-        initialValue?.constructor.name === 'Date' ||
-        Array.isArray(initialValue)
-      ) {
+      if (propertyDefinition instanceof NullableProperty) {
+        const value =
+          initialValue === null || isModelValueType(initialValue)
+            ? initialValue
+            : propertyDefinition.getValue()
+
+        set(properties, propertyName, value)
+        return properties
+      }
+
+      if (isModelValueType(initialValue)) {
         log(
           '"%s" has a plain initial value:',
           `${modelName}.${propertyName}`,

--- a/src/model/defineRelationalProperties.ts
+++ b/src/model/defineRelationalProperties.ts
@@ -26,9 +26,17 @@ export function defineRelationalProperties(
       relation.target.modelName,
     )
 
-    const references: Value<any, ModelDictionary> | undefined = get(
+    const references: Value<any, ModelDictionary> | null | undefined = get(
       initialValues,
       propertyPath,
+    )
+
+    invariant(
+      references !== null || relation.attributes.nullable,
+      'Failed to define a "%s" relational property to "%s" on "%s": a non-nullable relation cannot be instantiated with null. Use the "nullable" function when defining this relation to support nullable value.',
+      relation.kind,
+      propertyPath.join('.'),
+      entity[ENTITY_TYPE],
     )
 
     log(

--- a/src/model/defineRelationalProperties.ts
+++ b/src/model/defineRelationalProperties.ts
@@ -32,7 +32,9 @@ export function defineRelationalProperties(
     )
 
     log(
-      `setting relational property "${entity.__type}.${propertyPath.join('.')}" with references: %j`,
+      `setting relational property "${entity.__type}.${propertyPath.join(
+        '.',
+      )}" with references: %j`,
       relation,
       references,
     )
@@ -41,7 +43,7 @@ export function defineRelationalProperties(
 
     if (references) {
       relation.resolveWith(entity, references)
-    } else if (relation.nullable) {
+    } else if (relation.attributes.nullable) {
       relation.resolveWith(entity, null)
     }
   }

--- a/src/model/defineRelationalProperties.ts
+++ b/src/model/defineRelationalProperties.ts
@@ -41,6 +41,8 @@ export function defineRelationalProperties(
 
     if (references) {
       relation.resolveWith(entity, references)
+    } else if (relation.nullable) {
+      relation.resolveWith(entity, null)
     }
   }
 }

--- a/src/model/generateRestHandlers.ts
+++ b/src/model/generateRestHandlers.ts
@@ -125,7 +125,7 @@ export function generateRestHandlers<
   const primaryKey = findPrimaryKey(modelDefinition)!
   const primaryKeyValue = (
     modelDefinition[primaryKey] as PrimaryKey<PrimaryKeyType>
-  ).getValue()
+  ).getPrimaryKeyValue()
   const modelPath = pluralize(modelName)
   const buildUrl = createUrlBuilder(baseUrl)
 

--- a/src/model/parseModelDefinition.ts
+++ b/src/model/parseModelDefinition.ts
@@ -9,6 +9,7 @@ import {
 import { PrimaryKey } from '../primaryKey'
 import { isObject } from '../utils/isObject'
 import { Relation, RelationsList } from '../relations/Relation'
+import { NullableProperty } from '../nullable'
 
 const log = debug('parseModelDefinition')
 
@@ -66,6 +67,12 @@ function deepParseModelDefinition<Dictionary extends ModelDictionary>(
       result.primaryKey = propertyName
       result.properties.push([propertyName])
 
+      continue
+    }
+
+    if (value instanceof NullableProperty) {
+      // Add nullable properties to the same list as regular properties
+      result.properties.push(propertyPath)
       continue
     }
 

--- a/src/model/updateEntity.ts
+++ b/src/model/updateEntity.ts
@@ -73,7 +73,7 @@ export function updateEntity(
           )
 
           invariant(
-            (value === null && propertyDefinition.nullable) ||
+            (value === null && propertyDefinition.attributes.nullable) ||
               isObject(value) ||
               Array.isArray(value),
             'Failed to update relational property "%s" on "%s": the next value must be an entity, a list of entities, or null if relation is nullable',

--- a/src/model/updateEntity.ts
+++ b/src/model/updateEntity.ts
@@ -11,6 +11,7 @@ import {
 } from '../glossary'
 import { isObject } from '../utils/isObject'
 import { inheritInternalProperties } from '../utils/inheritInternalProperties'
+import { NullableProperty } from '../nullable'
 
 const log = debug('updateEntity')
 
@@ -72,8 +73,10 @@ export function updateEntity(
           )
 
           invariant(
-            isObject(value) || Array.isArray(value),
-            'Failed to update relational property "%s" on "%s": the next value must be an entity or a list of entities.',
+            (value === null && propertyDefinition.nullable) ||
+              isObject(value) ||
+              Array.isArray(value),
+            'Failed to update relational property "%s" on "%s": the next value must be an entity, a list of entities, or null if relation is nullable',
             propertyName,
             propertyDefinition.source.modelName,
           )
@@ -81,7 +84,10 @@ export function updateEntity(
           log('updating the relation to resolve with:', value)
 
           // Re-define the relational property to now point at the next value.
-          propertyDefinition.resolveWith(nextEntity, value as Value<any, any>[])
+          propertyDefinition.resolveWith(
+            nextEntity,
+            value as Value<any, any>[] | null,
+          )
 
           return nextEntity
         }
@@ -100,6 +106,11 @@ export function updateEntity(
           typeof value === 'function' ? value(prevValue, entity) : value
 
         log('setting a value at "%s" to: %s', propertyName, nextValue)
+        invariant(
+          nextValue !== null || propertyDefinition instanceof NullableProperty,
+          'Failed to set value at "%s" to null as the property is not nullable. Use the "nullable" function when defining your property',
+          propertyName,
+        )
         nextEntity[propertyName] = nextValue
 
         log('next entity:', nextEntity)

--- a/src/nullable.ts
+++ b/src/nullable.ts
@@ -16,16 +16,20 @@ export function nullable<ValueType extends ModelValueType>(
   value: NullableGetter<ValueType>,
 ): NullableProperty<ValueType>
 
-export function nullable<ValueType extends Relation<any, any, any, false>>(
+export function nullable<
+  ValueType extends Relation<any, any, any, { nullable: false }>,
+>(
   value: ValueType,
-): ValueType extends Relation<infer Kind, infer Key, any, false>
+): ValueType extends Relation<infer Kind, infer Key, any, { nullable: false }>
   ? Kind extends RelationKind.ManyOf
     ? ManyOf<Key, true>
     : OneOf<Key, true>
   : never
 
 export function nullable(
-  value: NullableGetter<ModelValueType> | Relation<any, any, any, false>,
+  value:
+    | NullableGetter<ModelValueType>
+    | Relation<any, any, any, { nullable: false }>,
 ) {
   if (typeof value === 'function') {
     return new NullableProperty(value)
@@ -33,8 +37,10 @@ export function nullable(
 
   return new Relation({
     kind: value.kind,
-    attributes: value.attributes,
     to: value.target.modelName,
-    nullable: true,
+    attributes: {
+      ...value.attributes,
+      nullable: true,
+    },
   })
 }

--- a/src/nullable.ts
+++ b/src/nullable.ts
@@ -1,0 +1,40 @@
+import { ModelValueType } from './glossary'
+import { ManyOf, OneOf, Relation, RelationKind } from './relations/Relation'
+
+export type NullableGetter<ValueType extends ModelValueType> =
+  () => ValueType | null
+
+export class NullableProperty<ValueType extends ModelValueType> {
+  public getValue: NullableGetter<ValueType>
+
+  constructor(getter: NullableGetter<ValueType>) {
+    this.getValue = getter
+  }
+}
+
+export function nullable<ValueType extends ModelValueType>(
+  value: NullableGetter<ValueType>,
+): NullableProperty<ValueType>
+
+export function nullable<ValueType extends Relation<any, any, any, false>>(
+  value: ValueType,
+): ValueType extends Relation<infer Kind, infer Key, any, false>
+  ? Kind extends RelationKind.ManyOf
+    ? ManyOf<Key, true>
+    : OneOf<Key, true>
+  : never
+
+export function nullable(
+  value: NullableGetter<ModelValueType> | Relation<any, any, any, false>,
+) {
+  if (typeof value === 'function') {
+    return new NullableProperty(value)
+  }
+
+  return new Relation({
+    kind: value.kind,
+    attributes: value.attributes,
+    to: value.target.modelName,
+    nullable: true,
+  })
+}

--- a/src/primaryKey.ts
+++ b/src/primaryKey.ts
@@ -3,10 +3,10 @@ import { PrimaryKeyType } from './glossary'
 export type PrimaryKeyGetter<ValueType extends PrimaryKeyType> = () => ValueType
 
 export class PrimaryKey<ValueType extends PrimaryKeyType = string> {
-  public getValue: PrimaryKeyGetter<ValueType>
+  public getPrimaryKeyValue: PrimaryKeyGetter<ValueType>
 
   constructor(getter: PrimaryKeyGetter<ValueType>) {
-    this.getValue = getter
+    this.getPrimaryKeyValue = getter
   }
 }
 

--- a/src/query/compileQuery.ts
+++ b/src/query/compileQuery.ts
@@ -34,7 +34,7 @@ export function compileQuery<Data extends Record<string, any>>(
 
         // If an entity doesn't have any value for the property
         // is being queried for, treat it as non-matching.
-        if (typeof actualValue === 'undefined') {
+        if (actualValue == null) {
           return false
         }
 

--- a/src/utils/isModelValueType.ts
+++ b/src/utils/isModelValueType.ts
@@ -1,0 +1,17 @@
+import { ModelValueType, PrimitiveValueType } from '../glossary'
+
+function isPrimitiveValueType(value: any): value is PrimitiveValueType {
+  return (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    value?.constructor?.name === 'Date'
+  )
+}
+
+export function isModelValueType(value: any): value is ModelValueType {
+  return (
+    isPrimitiveValueType(value) ||
+    (Array.isArray(value) && value.every(isPrimitiveValueType))
+  )
+}

--- a/test/model/create.test-d.ts
+++ b/test/model/create.test-d.ts
@@ -14,8 +14,8 @@ const db = factory({
     },
   },
   company: {
-    name: primaryKey(String)
-  }
+    name: primaryKey(String),
+  },
 })
 
 // @ts-expect-error Unknown model name.
@@ -30,6 +30,11 @@ db.user.create({
       country: 'us',
     },
   },
+})
+
+db.user.create({
+  // @ts-expect-error Non-nullable properties cannot be instantiated with null.
+  firstName: null,
 })
 
 db.user.create({

--- a/test/model/create.test-d.ts
+++ b/test/model/create.test-d.ts
@@ -1,15 +1,21 @@
-import { factory, primaryKey } from '@mswjs/data'
+import { factory, primaryKey, nullable } from '@mswjs/data'
+import faker from 'faker'
 
 const db = factory({
   user: {
     id: primaryKey(String),
     firstName: String,
+    lastName: nullable(faker.name.lastName),
+    age: nullable<number>(() => null),
     address: {
       billing: {
         country: String,
       },
     },
   },
+  company: {
+    name: primaryKey(String)
+  }
 })
 
 // @ts-expect-error Unknown model name.
@@ -60,3 +66,15 @@ db.user.create({
   // will be executed to get the initial value.
   firstName: 'John',
 })
+
+const user = db.user.create({
+  // Nullable properties can have an initialValue of null or the property type
+  lastName: null,
+  age: 15,
+})
+
+// @ts-expect-error lastName property is possibly null
+user.lastName.toUpperCase()
+
+// @ts-expect-error property 'toUpperCase' does not exist on type 'number'
+user.age?.toUpperCase()

--- a/test/model/create.test.ts
+++ b/test/model/create.test.ts
@@ -1,5 +1,5 @@
-import { datatype } from 'faker'
-import { factory, primaryKey, oneOf } from '@mswjs/data'
+import { datatype, name } from 'faker'
+import { factory, primaryKey, oneOf, nullable } from '@mswjs/data'
 import { identity } from '../../src/utils/identity'
 
 test('creates a new entity', () => {
@@ -44,6 +44,29 @@ test('creates a new entity with an array property', () => {
   })
   expect(exactUser).toHaveProperty('id', 'abc-123')
   expect(exactUser).toHaveProperty('arrayProp', [1, 2, 3])
+})
+
+test('creates a new entity with nullable properties', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(datatype.uuid),
+      name: nullable(name.findName),
+      age: nullable<number>(() => null),
+      address: {
+        street: String,
+        number: nullable<number>(() => null),
+      },
+    },
+  })
+
+  const user = db.user.create({
+    id: 'abc-123',
+    name: null,
+  })
+
+  expect(user).toHaveProperty('name', null)
+  expect(user).toHaveProperty('age', null)
+  expect(user.address).toHaveProperty('number', null)
 })
 
 test('supports nested objects in the model definition', () => {

--- a/test/model/create.test.ts
+++ b/test/model/create.test.ts
@@ -1,5 +1,5 @@
 import { datatype, name } from 'faker'
-import { factory, primaryKey, oneOf, nullable } from '@mswjs/data'
+import { factory, primaryKey, oneOf, manyOf, nullable } from '@mswjs/data'
 import { identity } from '../../src/utils/identity'
 
 test('creates a new entity', () => {
@@ -184,4 +184,43 @@ test('supports property names with dots in model definition', () => {
   })
 
   expect(user).toHaveProperty(['employee.id'], 'abc-123')
+})
+
+test('throws an exception when null used as initial value for non-nullable properties', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(datatype.uuid),
+      name: String,
+    },
+  })
+
+  expect(() => {
+    db.user.create({
+      // @ts-expect-error Cannot use null as the initial value for a non-nullable property.
+      name: null,
+    })
+  }).toThrowError(
+    'Failed to create a "user" entity: a non-nullable property "name" cannot be instantiated with null. Use the "nullable" function when defining this property to support nullable value.',
+  )
+})
+
+test('throws an exception when null used as initial value for non-nullable relations', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(datatype.uuid),
+      posts: manyOf('post'),
+    },
+    post: {
+      id: primaryKey(datatype.uuid),
+    },
+  })
+
+  expect(() => {
+    db.user.create({
+      // @ts-expect-error Cannot use null as the initial value for a non-nullable relation.
+      posts: null,
+    })
+  }).toThrowError(
+    'Failed to define a "MANY_OF" relational property to "posts" on "user": a non-nullable relation cannot be instantiated with null. Use the "nullable" function when defining this relation to support nullable value.',
+  )
 })

--- a/test/model/relationalProperties.test.ts
+++ b/test/model/relationalProperties.test.ts
@@ -1,4 +1,4 @@
-import { oneOf, primaryKey } from '../../src'
+import { oneOf, primaryKey, nullable } from '../../src'
 import {
   Relation,
   RelationKind,
@@ -18,6 +18,51 @@ it('marks relational properties as enumerable', () => {
       id: primaryKey(String),
       title: String,
       author: oneOf('user'),
+    },
+  }
+
+  const db = new Database(dictionary)
+
+  db.create('user', {
+    [ENTITY_TYPE]: 'user',
+    [PRIMARY_KEY]: 'id',
+    id: 'abc-123',
+    name: 'Test User',
+  })
+
+  const relations: RelationsList = [
+    {
+      propertyPath: ['author'],
+      relation: new Relation({
+        to: 'user',
+        kind: RelationKind.OneOf,
+      }),
+    },
+  ]
+
+  const post = {
+    [ENTITY_TYPE]: 'post',
+    [PRIMARY_KEY]: 'id',
+    id: '234',
+    title: 'Test Post',
+  }
+  const initialValues = { author: { id: 'abc-123' } }
+
+  defineRelationalProperties(post, initialValues, relations, dictionary, db)
+
+  expect(post.propertyIsEnumerable('author')).toBe(true)
+})
+
+it('marks nullable relational properties as enumerable', () => {
+  const dictionary: ModelDictionary = {
+    user: {
+      id: primaryKey(String),
+      name: String,
+    },
+    post: {
+      id: primaryKey(String),
+      title: String,
+      author: nullable(oneOf('user')),
     },
   }
 

--- a/test/model/update.test-d.ts
+++ b/test/model/update.test-d.ts
@@ -1,20 +1,29 @@
-import { factory, oneOf, primaryKey } from '../..'
+import faker from 'faker'
+import { factory, oneOf, manyOf, primaryKey, nullable } from '@mswjs/data'
 
 const db = factory({
   user: {
     id: primaryKey(String),
     firstName: String,
+    lastName: nullable(faker.name.lastName),
     age: Number,
     createdAt: () => new Date(),
     country: oneOf('country'),
+    company: nullable(oneOf('company')),
     address: {
       billing: {
         country: String,
+        city: nullable<string>(() => null),
       },
     },
   },
   country: {
     code: primaryKey(String),
+  },
+  company: {
+    name: primaryKey(String),
+    employees: manyOf('user'),
+    countries: nullable(manyOf('country')),
   },
 })
 
@@ -42,6 +51,10 @@ db.user.update({
     firstName: 'next',
     age: 24,
     country: db.country.create({ code: 'de' }),
+    company: db.company.create({ name: 'Umbrella' }),
+    lastName: null,
+    // @ts-expect-error Unable to update non-nullable values to null
+    updatedAt: null,
   },
 })
 
@@ -60,8 +73,37 @@ db.user.update({
     address: {
       billing: {
         country: 'de',
+        city: 'Berlin',
       },
     },
+  },
+})
+
+// Update nullable hasOne relations to null
+db.user.update({
+  where: {
+    id: {
+      equals: 'abc-123',
+    },
+  },
+  data: {
+    company: null,
+    // @ts-expect-error unable to update non-nullable relations to null
+    country: null,
+  },
+})
+
+// Update nullable hasMany relations to null
+db.company.update({
+  where: {
+    name: {
+      equals: 'Umbrella',
+    },
+  },
+  data: {
+    countries: null,
+    // @ts-expect-error unable to update non-nullable hasMany relations to null
+    employees: null,
   },
 })
 

--- a/test/query/date.test.ts
+++ b/test/query/date.test.ts
@@ -1,5 +1,5 @@
 import { datatype } from 'faker'
-import { factory, primaryKey } from '@mswjs/data'
+import { factory, primaryKey, nullable } from '@mswjs/data'
 
 const setup = () => {
   const db = factory({
@@ -7,15 +7,18 @@ const setup = () => {
       id: primaryKey(datatype.uuid),
       firstName: String,
       createdAt: () => new Date(),
+      updatedAt: nullable<Date>(() => null),
     },
   })
   db.user.create({
     firstName: 'John',
     createdAt: new Date('1980-04-12'),
+    updatedAt: new Date('1980-04-12'),
   })
   db.user.create({
     firstName: 'Kate',
     createdAt: new Date('2013-08-09'),
+    updatedAt: new Date('2014-01-01'),
   })
   db.user.create({
     firstName: 'Sedrik',
@@ -118,4 +121,22 @@ test('queries entities that are newer or equal to a date', () => {
 
   const userNames = userResults.map((user) => user.firstName)
   expect(userNames).toEqual(['Kate'])
+})
+
+test('ignores entities with missing values when querying using date', () => {
+  const db = setup()
+
+  const date = new Date('2000-01-01')
+  const updatedBefore = db.user.findMany({
+    where: { updatedAt: { lte: date } },
+  })
+  const updatedAfter = db.user.findMany({
+    where: { updatedAt: { gte: date } },
+  })
+  const updatedUserNames = [...updatedBefore, ...updatedAfter].map(
+    (user) => user.firstName,
+  )
+
+  expect(updatedUserNames).toHaveLength(2)
+  expect(updatedUserNames).not.toContain('Sedrick')
 })

--- a/test/query/number.test.ts
+++ b/test/query/number.test.ts
@@ -1,5 +1,5 @@
 import { datatype } from 'faker'
-import { factory, primaryKey } from '@mswjs/data'
+import { factory, primaryKey, nullable } from '@mswjs/data'
 
 const setup = () => {
   const db = factory({
@@ -7,15 +7,18 @@ const setup = () => {
       id: primaryKey(datatype.uuid),
       firstName: String,
       age: Number,
+      height: nullable<number>(() => null),
     },
   })
   db.user.create({
     firstName: 'John',
     age: 16,
+    height: 200,
   })
   db.user.create({
     firstName: 'Alice',
     age: 24,
+    height: 165,
   })
   db.user.create({
     firstName: 'Kate',
@@ -189,4 +192,18 @@ test('queries entities where property is contained into the array', () => {
   })
   const names = users.map((user) => user.firstName)
   expect(names).toEqual(['John', 'Alice'])
+})
+
+test('ignores entities with missing values when querying using number', () => {
+  const db = setup()
+
+  const height = 180
+  const shorterUsers = db.user.findMany({ where: { height: { lt: height } } })
+  const tallerUsers = db.user.findMany({ where: { height: { gte: height } } })
+  const userNames = [...shorterUsers, ...tallerUsers].map(
+    (user) => user.firstName,
+  )
+
+  expect(userNames).toHaveLength(2)
+  expect(userNames).toEqual(['Alice', 'John'])
 })

--- a/test/relations/many-to-one.test.ts
+++ b/test/relations/many-to-one.test.ts
@@ -1,4 +1,4 @@
-import { factory, oneOf, primaryKey } from '@mswjs/data'
+import { factory, oneOf, primaryKey, nullable } from '@mswjs/data'
 import { ENTITY_TYPE, PRIMARY_KEY } from '../../lib/glossary'
 
 test('supports querying by a many-to-one relation', () => {
@@ -31,6 +31,77 @@ test('supports querying by a many-to-one relation', () => {
     id: 'post-3',
     title: 'Third post',
     author,
+  })
+
+  const userPosts = db.post.findMany({
+    where: {
+      author: {
+        id: {
+          equals: author.id,
+        },
+      },
+    },
+  })
+
+  expect(userPosts).toEqual([
+    {
+      [ENTITY_TYPE]: 'post',
+      [PRIMARY_KEY]: 'id',
+      id: 'post-1',
+      title: 'First post',
+      author: author,
+    },
+    {
+      [ENTITY_TYPE]: 'post',
+      [PRIMARY_KEY]: 'id',
+      id: 'post-2',
+      title: 'Second post',
+      author: author,
+    },
+    {
+      [ENTITY_TYPE]: 'post',
+      [PRIMARY_KEY]: 'id',
+      id: 'post-3',
+      title: 'Third post',
+      author: author,
+    },
+  ])
+})
+
+test('supports querying by a nullable many-to-one relation', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(String),
+    },
+    post: {
+      id: primaryKey(String),
+      title: String,
+      author: nullable(oneOf('user')),
+    },
+  })
+
+  const author = db.user.create({
+    id: 'user-1',
+  })
+
+  db.post.create({
+    id: 'post-1',
+    title: 'First post',
+    author,
+  })
+  db.post.create({
+    id: 'post-2',
+    title: 'Second post',
+    author,
+  })
+  db.post.create({
+    id: 'post-3',
+    title: 'Third post',
+    author,
+  })
+  db.post.create({
+    id: 'post-4',
+    title: 'Fourth post',
   })
 
   const userPosts = db.post.findMany({
@@ -154,6 +225,99 @@ test('supports querying by a nested many-to-one relation', () => {
   ])
 })
 
+test('supports querying by a nested nullable many-to-one relation', () => {
+  const db = factory({
+    role: {
+      name: primaryKey(String),
+    },
+    user: {
+      id: primaryKey(String),
+      role: nullable(oneOf('role')),
+    },
+    post: {
+      id: primaryKey(String),
+      author: oneOf('user'),
+    },
+  })
+
+  const editor = db.role.create({
+    name: 'editor',
+  })
+  const reader = db.role.create({
+    name: 'reader',
+  })
+
+  const john = db.user.create({
+    id: 'john',
+    role: editor,
+  })
+  const kate = db.user.create({
+    id: 'kate',
+    role: reader,
+  })
+  const guest = db.user.create({
+    id: 'guest',
+  })
+  db.user.create({
+    id: 'joseph',
+    role: reader,
+  })
+
+  db.post.create({
+    id: 'post-1',
+    author: john,
+  })
+  db.post.create({
+    id: 'post-2',
+    author: john,
+  })
+  db.post.create({
+    id: 'post-3',
+    author: kate,
+  })
+  db.post.create({
+    id: 'post-4',
+    author: john,
+  })
+  db.post.create({
+    id: 'post-5',
+    author: guest,
+  })
+
+  const posts = db.post.findMany({
+    where: {
+      author: {
+        role: {
+          name: {
+            equals: 'editor',
+          },
+        },
+      },
+    },
+  })
+
+  expect(posts).toEqual([
+    {
+      [ENTITY_TYPE]: 'post',
+      [PRIMARY_KEY]: 'id',
+      id: 'post-1',
+      author: john,
+    },
+    {
+      [ENTITY_TYPE]: 'post',
+      [PRIMARY_KEY]: 'id',
+      id: 'post-2',
+      author: john,
+    },
+    {
+      [ENTITY_TYPE]: 'post',
+      [PRIMARY_KEY]: 'id',
+      id: 'post-4',
+      author: john,
+    },
+  ])
+})
+
 test('updates a many-to-one relational property without initial value', () => {
   const db = factory({
     user: {
@@ -162,6 +326,54 @@ test('updates a many-to-one relational property without initial value', () => {
     post: {
       id: primaryKey(String),
       author: oneOf('user'),
+    },
+  })
+
+  db.post.create({
+    id: 'post-1',
+  })
+
+  const updatedPost = db.post.update({
+    where: {
+      id: {
+        equals: 'post-1',
+      },
+    },
+    data: {
+      author: db.user.create({ id: 'john' }),
+    },
+  })
+
+  expect(updatedPost).toEqual({
+    [ENTITY_TYPE]: 'post',
+    [PRIMARY_KEY]: 'id',
+    id: 'post-1',
+    author: {
+      [ENTITY_TYPE]: 'user',
+      [PRIMARY_KEY]: 'id',
+      id: 'john',
+    },
+  })
+
+  expect(
+    db.post.findFirst({
+      where: {
+        id: {
+          equals: 'post-1',
+        },
+      },
+    }),
+  ).toEqual(updatedPost)
+})
+
+test('updates a nullable many-to-one relational property without initial value', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(String),
+    },
+    post: {
+      id: primaryKey(String),
+      author: nullable(oneOf('user')),
     },
   })
 
@@ -225,5 +437,32 @@ test('does not throw any error when a many-to-one entity is created without a re
     [PRIMARY_KEY]: 'id',
     id: 'post-1',
     title: 'First post',
+  })
+})
+
+test('does not throw any error when a nullable many-to-one entity is created without a relation', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(String),
+      firstName: String,
+    },
+    post: {
+      id: primaryKey(String),
+      title: String,
+      author: nullable(oneOf('user')),
+    },
+  })
+
+  const post = db.post.create({
+    id: 'post-1',
+    title: 'First post',
+  })
+
+  expect(post).toEqual({
+    [ENTITY_TYPE]: 'post',
+    [PRIMARY_KEY]: 'id',
+    id: 'post-1',
+    title: 'First post',
+    author: null,
   })
 })

--- a/test/relations/one-to-many.test.ts
+++ b/test/relations/one-to-many.test.ts
@@ -1,4 +1,4 @@
-import { factory, primaryKey, manyOf } from '@mswjs/data'
+import { factory, primaryKey, manyOf, nullable } from '@mswjs/data'
 import { ENTITY_TYPE, PRIMARY_KEY } from '../../lib/glossary'
 
 test('supports one-to-many relation', () => {
@@ -39,7 +39,60 @@ test('supports one-to-many relation', () => {
   ).toEqual(user)
 })
 
-test('supports updating a recusrive one-to-many relation', () => {
+test('supports nullable one-to-many relation', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(String),
+      posts: nullable(manyOf('post')),
+    },
+    post: {
+      id: primaryKey(String),
+      title: String,
+    },
+  })
+
+  const firstPost = db.post.create({
+    id: 'post-1',
+    title: 'First post',
+  })
+  const secondPost = db.post.create({
+    id: 'post-2',
+    title: 'Second post',
+  })
+  const user = db.user.create({
+    id: 'user-1',
+    posts: [firstPost, secondPost],
+  })
+
+  expect(user.posts).toEqual([firstPost, secondPost])
+
+  expect(
+    db.user.findFirst({
+      where: {
+        id: {
+          equals: 'user-1',
+        },
+      },
+    }),
+  ).toEqual(user)
+
+  const postlessUser = db.user.create({
+    id: 'user-2',
+  })
+  expect(postlessUser.posts).toBeNull()
+
+  expect(
+    db.user.findFirst({
+      where: {
+        id: {
+          equals: 'user-2',
+        },
+      },
+    }),
+  ).toEqual(postlessUser)
+})
+
+test('supports updating a recursive one-to-many relation', () => {
   const db = factory({
     user: {
       id: primaryKey(String),
@@ -79,6 +132,71 @@ test('supports updating a recusrive one-to-many relation', () => {
 
   expect(updatedJohn.friends).toHaveLength(1)
   expect(updatedJohn.friends[0]).toHaveProperty('firstName', 'Kate')
+})
+
+test('supports updating a recursive nullable one-to-many relation', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(String),
+      firstName: String,
+      friends: nullable(manyOf('user')),
+    },
+  })
+
+  const john = db.user.create({
+    id: 'john',
+    firstName: 'John',
+    friends: [],
+  })
+
+  const kate = db.user.create({
+    id: 'kate',
+    firstName: 'Kate',
+    friends: [john],
+  })
+
+  db.user.findFirst({
+    where: { id: { equals: 'john' } },
+    strict: true,
+  })
+
+  const updatedJohn = db.user.update({
+    where: {
+      id: {
+        equals: john.id,
+      },
+    },
+    data: {
+      friends: [kate],
+    },
+    strict: true,
+  })!
+
+  expect(updatedJohn.friends).toHaveLength(1)
+  expect(updatedJohn.friends?.shift()).toHaveProperty('firstName', 'Kate')
+
+  const jack = db.user.create({
+    id: 'jack',
+    firstName: 'Jack',
+    friends: null,
+  })
+
+  expect(jack.friends).toBeNull()
+
+  const updatedJack = db.user.update({
+    where: {
+      id: {
+        equals: john.id,
+      },
+    },
+    data: {
+      friends: [john],
+    },
+    strict: true,
+  })!
+
+  expect(updatedJack.friends).toHaveLength(1)
+  expect(updatedJack.friends?.shift()).toHaveProperty('firstName', 'John')
 })
 
 test('supports querying through one-to-many relation', () => {
@@ -154,6 +272,84 @@ test('supports querying through one-to-many relation', () => {
   ])
 })
 
+test('supports querying through nullable one-to-many relation', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(String),
+      posts: nullable(manyOf('post')),
+    },
+    post: {
+      id: primaryKey(String),
+      title: String,
+    },
+  })
+
+  const firstUserPosts = [
+    db.post.create({
+      id: 'post-1-1',
+      title: 'First post',
+    }),
+    db.post.create({
+      id: 'post-1-2',
+      title: 'Second post',
+    }),
+  ]
+
+  db.user.create({
+    id: 'user-1',
+    posts: firstUserPosts,
+  })
+
+  db.user.create({
+    id: 'user-2',
+    posts: [
+      db.post.create({
+        id: 'post-2-1',
+        title: 'Third post',
+      }),
+    ],
+  })
+
+  const thirdUserPosts = [
+    db.post.create({ id: 'post-3-1', title: 'Second post' }),
+    db.post.create({ id: 'post-3-2', title: 'Fourth post' }),
+  ]
+  db.user.create({
+    id: 'user-3',
+    posts: thirdUserPosts,
+  })
+
+  db.user.create({
+    id: 'user-4',
+    posts: null,
+  })
+
+  const users = db.user.findMany({
+    where: {
+      posts: {
+        title: {
+          in: ['First post', 'Second post'],
+        },
+      },
+    },
+  })
+
+  expect(users).toEqual([
+    {
+      [ENTITY_TYPE]: 'user',
+      [PRIMARY_KEY]: 'id',
+      id: 'user-1',
+      posts: firstUserPosts,
+    },
+    {
+      [ENTITY_TYPE]: 'user',
+      [PRIMARY_KEY]: 'id',
+      id: 'user-3',
+      posts: thirdUserPosts,
+    },
+  ])
+})
+
 test('supports querying through a nested one-to-many relation', () => {
   const db = factory({
     user: {
@@ -192,11 +388,75 @@ test('supports querying through a nested one-to-many relation', () => {
   expect(result).toEqual(user)
 })
 
+test('supports querying through a nested nullable one-to-many relation', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(String),
+      activity: {
+        posts: nullable(manyOf('post')),
+      },
+    },
+    post: {
+      id: primaryKey(String),
+    },
+  })
+
+  const user = db.user.create({
+    id: 'user-1',
+    activity: {
+      posts: [
+        db.post.create({ id: 'post-1' }),
+        db.post.create({ id: 'post-2' }),
+      ],
+    },
+  })
+
+  const result = db.user.findFirst({
+    where: {
+      activity: {
+        posts: {
+          id: {
+            equals: 'post-2',
+          },
+        },
+      },
+    },
+  })
+
+  expect(result).toEqual(user)
+})
+
 test('supports creating an entity without specifying the value for one-to-many relation', () => {
   const db = factory({
     user: {
       id: primaryKey(String),
       posts: manyOf('post'),
+    },
+    post: {
+      id: primaryKey(String),
+    },
+  })
+
+  const user = db.user.create({
+    id: 'abc-123',
+  })
+
+  expect(
+    db.user.findFirst({
+      where: {
+        id: {
+          equals: 'abc-123',
+        },
+      },
+    }),
+  ).toEqual(user)
+})
+
+test('supports creating an entity without specifying the value for a nullable one-to-many relation', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(String),
+      posts: nullable(manyOf('post')),
     },
     post: {
       id: primaryKey(String),
@@ -284,11 +544,161 @@ test('updates a one-to-many relational property', () => {
   })
 })
 
+test('updates a nullable one-to-many relational property', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(String),
+      posts: nullable(manyOf('post')),
+    },
+    post: {
+      id: primaryKey(String),
+      title: String,
+    },
+  })
+
+  const firstPost = db.post.create({
+    id: 'post-1',
+    title: 'First post',
+  })
+  const secondPost = db.post.create({
+    id: 'post-2',
+    title: 'Second post',
+  })
+  const user = db.user.create({
+    id: 'abc-123',
+    posts: [firstPost],
+  })
+  const refetchUser = () => {
+    return db.user.findFirst({
+      where: {
+        id: {
+          equals: 'abc-123',
+        },
+      },
+    })
+  }
+
+  expect(user.posts).toEqual([firstPost])
+  expect(refetchUser()).toEqual({
+    [ENTITY_TYPE]: 'user',
+    [PRIMARY_KEY]: 'id',
+    id: 'abc-123',
+    posts: [firstPost],
+  })
+
+  // Update the "posts" relational property.
+  let updatedUser = db.user.update({
+    where: {
+      id: { equals: 'abc-123' },
+    },
+    data: {
+      posts: [secondPost],
+    },
+  })
+
+  expect(updatedUser).toEqual({
+    [ENTITY_TYPE]: 'user',
+    [PRIMARY_KEY]: 'id',
+    id: 'abc-123',
+    posts: [secondPost],
+  })
+  expect(refetchUser()).toEqual({
+    [ENTITY_TYPE]: 'user',
+    [PRIMARY_KEY]: 'id',
+    id: 'abc-123',
+    posts: [secondPost],
+  })
+
+  // Update the "posts" relational property to null.
+  updatedUser = db.user.update({
+    where: {
+      id: { equals: 'abc-123' },
+    },
+    data: {
+      posts: null,
+    },
+  })
+
+  expect(updatedUser).toEqual({
+    [ENTITY_TYPE]: 'user',
+    [PRIMARY_KEY]: 'id',
+    id: 'abc-123',
+    posts: null,
+  })
+  expect(refetchUser()).toEqual({
+    [ENTITY_TYPE]: 'user',
+    [PRIMARY_KEY]: 'id',
+    id: 'abc-123',
+    posts: null,
+  })
+})
+
 test('updates a one-to-many relational property without initial value', () => {
   const db = factory({
     user: {
       id: primaryKey(String),
       posts: manyOf('post'),
+    },
+    post: {
+      id: primaryKey(String),
+      title: String,
+    },
+  })
+
+  db.user.create({
+    id: 'user-1',
+  })
+
+  const updatedUser = db.user.update({
+    where: {
+      id: {
+        equals: 'user-1',
+      },
+    },
+    data: {
+      posts: [
+        db.post.create({ id: 'post-1', title: 'First post' }),
+        db.post.create({ id: 'post-2', title: 'Second post' }),
+      ],
+    },
+  })
+
+  expect(updatedUser).toEqual({
+    [ENTITY_TYPE]: 'user',
+    [PRIMARY_KEY]: 'id',
+    id: 'user-1',
+    posts: [
+      {
+        [ENTITY_TYPE]: 'post',
+        [PRIMARY_KEY]: 'id',
+        id: 'post-1',
+        title: 'First post',
+      },
+      {
+        [ENTITY_TYPE]: 'post',
+        [PRIMARY_KEY]: 'id',
+        id: 'post-2',
+        title: 'Second post',
+      },
+    ],
+  })
+
+  expect(
+    db.user.findFirst({
+      where: {
+        id: {
+          equals: 'user-1',
+        },
+      },
+    }),
+  ).toEqual(updatedUser)
+})
+
+test('updates a nullable one-to-many relational property without initial value', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(String),
+      posts: nullable(manyOf('post')),
     },
     post: {
       id: primaryKey(String),
@@ -473,5 +883,47 @@ test('throws an exception when updating a unique one-to-many relation to the alr
     }),
   ).toThrow(
     'Failed to create a unique "MANY_OF" relation to "post" ("user.posts") for "user-2": referenced post "post-1" belongs to another user ("user-1").',
+  )
+})
+
+test('throws an exception when updating a non-nullable one-to-many relation to null', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(String),
+      posts: manyOf('post'),
+    },
+    post: {
+      id: primaryKey(String),
+    },
+  })
+
+  const post = db.post.create({
+    id: 'post-1',
+  })
+
+  db.user.create({
+    id: 'user-1',
+    posts: [post],
+  })
+
+  db.user.create({
+    id: 'user-2',
+  })
+
+  expect(() =>
+    db.user.update({
+      where: {
+        id: {
+          equals: 'user-2',
+        },
+      },
+      data: {
+        // @ts-expect-error updating non-nullable relation to null not allowed
+        posts: null,
+      },
+      strict: true,
+    }),
+  ).toThrow(
+    'Failed to update relational property "posts" on "user": the next value must be an entity, a list of entities, or null if relation is nullable',
   )
 })

--- a/test/utils/isModelValueType.test.ts
+++ b/test/utils/isModelValueType.test.ts
@@ -1,0 +1,45 @@
+import { isModelValueType } from '../../src/utils/isModelValueType'
+
+it('returns true given a string', () => {
+  expect(isModelValueType('I am a string')).toBe(true)
+})
+
+it('returns true given a new string', () => {
+  expect(isModelValueType(String())).toBe(true)
+})
+
+it('returns true given a number', () => {
+  expect(isModelValueType(100)).toBe(true)
+})
+
+it('returns true given a new number', () => {
+  expect(isModelValueType(Number())).toBe(true)
+})
+
+it('returns true given a Date', () => {
+  expect(isModelValueType(new Date())).toBe(true)
+})
+
+it('returns true given a new array', () => {
+  expect(isModelValueType(new Array())).toBe(true)
+})
+
+it('returns true given an array with primitive values', () => {
+  expect(isModelValueType(['I am a string', 100])).toBe(true)
+})
+
+it('returns false given an undefined', () => {
+  expect(isModelValueType(undefined)).toBe(false)
+})
+
+it('returns false given a null', () => {
+  expect(isModelValueType(null)).toBe(false)
+})
+
+it('returns false when given an array with non-primitive values', () => {
+  expect(isModelValueType(['I am a string', {}])).toBe(false)
+})
+
+it('returns false when given nested primitive arrays', () => {
+  expect(isModelValueType(['I am a string', [100]])).toBe(false)
+})


### PR DESCRIPTION
closes #142 

New `nullable` function provides an API for defining nullable properties
as well as nullable relations.

The arguments passed to `nullable` are identical to those passed to
factory when the property is not nullable. This means `nullable` should
feel natural to use for users familiar to the project.

For example to define a nullable property the user passes the factory
function they would use to normally define the property to `nullable`
when defining the db. This matches the `primaryKey` method as a bonus.

To define a nullable relation they would pass the `oneOf` or `manyOf`
function with the model name directly to `nullable`.

The model API methods are all typed to know when it's possible for a
property to be null, and an invariant violation is raised for js users
who try to update a non-nullable property to null.