### PR TITLE
Support model properties with dots in them

### DIFF
--- a/src/model/defineRelationalProperties.ts
+++ b/src/model/defineRelationalProperties.ts
@@ -16,28 +16,28 @@ export function defineRelationalProperties(
 ): void {
   log('defining relational properties...', { entity, initialValues, relations })
 
-  for (const { path, relation } of relations) {
+  for (const { propertyPath, relation } of relations) {
     invariant(
       dictionary[relation.target.modelName],
       'Failed to define a "%s" relational property to "%s" on "%s": cannot find a model by the name "%s".',
       relation.kind,
-      path.join('.'),
+      propertyPath.join('.'),
       entity[ENTITY_TYPE],
       relation.target.modelName,
     )
 
     const references: Value<any, ModelDictionary> | undefined = get(
       initialValues,
-      path,
+      propertyPath,
     )
 
     log(
-      `setting relational property "${entity.__type}.${path.join('.')}" with references: %j`,
+      `setting relational property "${entity.__type}.${propertyPath.join('.')}" with references: %j`,
       relation,
       references,
     )
 
-    relation.apply(entity, path, dictionary, db)
+    relation.apply(entity, propertyPath, dictionary, db)
 
     if (references) {
       relation.resolveWith(entity, references)

--- a/src/model/defineRelationalProperties.ts
+++ b/src/model/defineRelationalProperties.ts
@@ -3,41 +3,41 @@ import get from 'lodash/get'
 import { invariant } from 'outvariant'
 import { Database } from '../db/Database'
 import { Entity, ENTITY_TYPE, ModelDictionary, Value } from '../glossary'
-import { RelationsMap } from '../relations/Relation'
+import { RelationsList } from '../relations/Relation'
 
 const log = debug('defineRelationalProperties')
 
 export function defineRelationalProperties(
   entity: Entity<any, any>,
   initialValues: Partial<Value<any, ModelDictionary>>,
-  relations: RelationsMap,
+  relations: RelationsList,
   dictionary: ModelDictionary,
   db: Database<any>,
 ): void {
   log('defining relational properties...', { entity, initialValues, relations })
 
-  for (const [propertyPath, relation] of Object.entries(relations)) {
+  for (const { path, relation } of relations) {
     invariant(
       dictionary[relation.target.modelName],
       'Failed to define a "%s" relational property to "%s" on "%s": cannot find a model by the name "%s".',
       relation.kind,
-      propertyPath,
+      path.join('.'),
       entity[ENTITY_TYPE],
       relation.target.modelName,
     )
 
     const references: Value<any, ModelDictionary> | undefined = get(
       initialValues,
-      propertyPath,
+      path,
     )
 
     log(
-      `setting relational property "${entity.__type}.${propertyPath}" with references: %j`,
+      `setting relational property "${entity.__type}.${path.join('.')}" with references: %j`,
       relation,
       references,
     )
 
-    relation.apply(entity, propertyPath, dictionary, db)
+    relation.apply(entity, path, dictionary, db)
 
     if (references) {
       relation.resolveWith(entity, references)

--- a/src/model/parseModelDefinition.ts
+++ b/src/model/parseModelDefinition.ts
@@ -72,7 +72,7 @@ function deepParseModelDefinition<Dictionary extends ModelDictionary>(
     // Relations.
     if (value instanceof Relation) {
       // Store the relations in a separate object.
-      result.relations.push({ path: propertyPath, relation: value })
+      result.relations.push({ propertyPath, relation: value })
       continue
     }
 

--- a/src/relations/Relation.ts
+++ b/src/relations/Relation.ts
@@ -67,7 +67,7 @@ export type ManyOf<ModelName extends KeyType> = Relation<
 >
 
 export type RelationsList = Array<{
-  path: string[]
+  propertyPath: string[]
   relation: Relation<any, any, any>
 }>
 

--- a/src/relations/Relation.ts
+++ b/src/relations/Relation.ts
@@ -32,7 +32,7 @@ export interface RelationAttributes {
 export interface RelationSource {
   modelName: string
   primaryKey: PrimaryKeyType
-  propertyPath: string
+  propertyPath: string[]
 }
 
 export interface RelationDefinition<
@@ -66,7 +66,10 @@ export type ManyOf<ModelName extends KeyType> = Relation<
   any
 >
 
-export type RelationsMap = Record<string, Relation<any, any, any>>
+export type RelationsList = Array<{
+  path: string[]
+  relation: Relation<any, any, any>
+}>
 
 const DEFAULT_RELATION_ATTRIBUTES: RelationAttributes = {
   unique: false,
@@ -118,7 +121,7 @@ export class Relation<
    */
   public apply(
     entity: Entity<any, any>,
-    propertyPath: string,
+    propertyPath: string[],
     dictionary: Dictionary,
     db: Database<Dictionary>,
   ) {

--- a/src/utils/definePropertyAtPath.ts
+++ b/src/utils/definePropertyAtPath.ts
@@ -13,17 +13,16 @@ import get from 'lodash/get'
  */
 export function definePropertyAtPath<AttributesType extends PropertyDescriptor>(
   target: Record<string, unknown>,
-  propertyPath: string,
+  propertyPath: string[],
   attributes: AttributesType,
 ) {
-  const segments = propertyPath.split('.')
-  const propertyName = segments[segments.length - 1]
-  const parentPath = segments.slice(0, -1).join('.')
+  const propertyName = propertyPath[propertyPath.length - 1]
+  const parentPath = propertyPath.slice(0, -1)
 
-  if (parentPath && !has(target, parentPath)) {
+  if (parentPath.length && !has(target, parentPath)) {
     set(target, parentPath, {})
   }
 
-  const parent = parentPath ? get(target, parentPath) : target
+  const parent = parentPath.length ? get(target, parentPath) : target
   Object.defineProperty(parent, propertyName, attributes)
 }

--- a/test/model/create.test.ts
+++ b/test/model/create.test.ts
@@ -148,3 +148,17 @@ test('uses value getters when creating an entity with nested arrays', () => {
   expect(exactUser.info).toHaveProperty('tags', [1, 2])
   expect(exactUser.info).toHaveProperty('documents', [])
 })
+
+test('model with properties that contain dots in them and can be considered a path', () => {
+  const db = factory({
+    user: {
+      'employee.id': primaryKey(datatype.uuid),
+    },
+  })
+
+  const dotUser = db.user.create({
+    'employee.id': 'abc-123',
+  })
+
+  expect(dotUser).toHaveProperty(['employee.id'], 'abc-123')
+})

--- a/test/model/create.test.ts
+++ b/test/model/create.test.ts
@@ -149,16 +149,16 @@ test('uses value getters when creating an entity with nested arrays', () => {
   expect(exactUser.info).toHaveProperty('documents', [])
 })
 
-test('model with properties that contain dots in them and can be considered a path', () => {
+test('supports property names with dots in model definition', () => {
   const db = factory({
     user: {
       'employee.id': primaryKey(datatype.uuid),
     },
   })
 
-  const dotUser = db.user.create({
+  const user = db.user.create({
     'employee.id': 'abc-123',
   })
 
-  expect(dotUser).toHaveProperty(['employee.id'], 'abc-123')
+  expect(user).toHaveProperty(['employee.id'], 'abc-123')
 })

--- a/test/model/relationalProperties.test.ts
+++ b/test/model/relationalProperties.test.ts
@@ -2,7 +2,7 @@ import { oneOf, primaryKey } from '../../src'
 import {
   Relation,
   RelationKind,
-  RelationsMap,
+  RelationsList,
 } from '../../src/relations/Relation'
 import { Database } from '../../src/db/Database'
 import { ENTITY_TYPE, ModelDictionary, PRIMARY_KEY } from '../../src/glossary'
@@ -30,12 +30,15 @@ it('marks relational properties as enumerable', () => {
     name: 'Test User',
   })
 
-  const relations: RelationsMap = {
-    author: new Relation({
-      to: 'user',
-      kind: RelationKind.OneOf,
-    }),
-  }
+  const relations: RelationsList = [
+    {
+      path: ['author'],
+      relation: new Relation({
+        to: 'user',
+        kind: RelationKind.OneOf,
+      }),
+    },
+  ]
 
   const post = {
     [ENTITY_TYPE]: 'post',

--- a/test/model/relationalProperties.test.ts
+++ b/test/model/relationalProperties.test.ts
@@ -32,7 +32,7 @@ it('marks relational properties as enumerable', () => {
 
   const relations: RelationsList = [
     {
-      path: ['author'],
+      propertyPath: ['author'],
       relation: new Relation({
         to: 'user',
         kind: RelationKind.OneOf,

--- a/test/relations/Relation.test.ts
+++ b/test/relations/Relation.test.ts
@@ -67,7 +67,7 @@ it('applies a "ONE_OF" relation to an entity', () => {
   })
   const user = users.get('user-1')!
 
-  relation.apply(user, 'birthPlace', dictionary, db)
+  relation.apply(user, ['birthPlace'], dictionary, db)
 
   // When applied, relation is updated with the additional info.
   expect(relation.target.primaryKey).toEqual('code')
@@ -113,7 +113,7 @@ it('applies a "MANY_OF" relation to an entity', () => {
   db.getModel('post').get('post-1')!
   db.getModel('post').get('post-2')!
 
-  relation.apply(user, 'posts', dictionary, db)
+  relation.apply(user, ['posts'], dictionary, db)
 
   expect(relation.source.modelName).toEqual('user')
   expect(relation.source.primaryKey).toEqual('id')
@@ -144,7 +144,7 @@ it('throws an exception when resolving a relation with a non-existing reference'
   })
   const user = users.get('user-1')!
 
-  relation.apply(user, 'birthPlace', dictionary, db)
+  relation.apply(user, ['birthPlace'], dictionary, db)
 
   expect(() => {
     relation.resolveWith(user, { code: 'us' })
@@ -190,7 +190,7 @@ it('throws an exception when resolving a unique relation that references an alre
   })
 
   // First, apply a new relation to the first user.
-  relation.apply(firstUser, 'birthPlace', dictionary, db)
+  relation.apply(firstUser, ['birthPlace'], dictionary, db)
   relation.resolveWith(firstUser, { code: 'us' })
 
   // Then, apply the relation t othe second user
@@ -234,7 +234,7 @@ it('does not throw an exception when updating the relational reference to the sa
   const country = countries.get('us')
 
   // First, apply and resolve a new relation for the first user.
-  relation.apply(user, 'birthPlace', dictionary, db)
+  relation.apply(user, ['birthPlace'], dictionary, db)
   relation.resolveWith(user, { code: 'us' })
 
   // Update the relational reference to the same referenced country.

--- a/test/utils/definePropertyAtPath.test.ts
+++ b/test/utils/definePropertyAtPath.test.ts
@@ -5,7 +5,7 @@ type AnyObject = Record<string, any>
 describe('definePropertyAtPath()', () => {
   it('defines a root property by give name', () => {
     const target: AnyObject = {}
-    definePropertyAtPath(target, 'a', {
+    definePropertyAtPath(target, ['a'], {
       get() {
         return 'hello world'
       },
@@ -15,11 +15,31 @@ describe('definePropertyAtPath()', () => {
 
   it('defines a nested property at a given path', () => {
     const target: AnyObject = {}
-    definePropertyAtPath(target, 'a.b.c', {
+    definePropertyAtPath(target, ['a', 'b', 'c'], {
       get() {
         return 'hello world'
       },
     })
     expect(target.a.b.c).toEqual('hello world')
+  })
+
+  it('defines properies with dots in them', () => {
+    const target: AnyObject = {}
+    definePropertyAtPath(target, ['a.b.c'], {
+      get() {
+        return 'hello world'
+      },
+    })
+    expect(target['a.b.c']).toEqual('hello world')
+  })
+
+  it('defines deep properies with dots in them', () => {
+    const target: AnyObject = {}
+    definePropertyAtPath(target, ['a.b.c', 'e.d.f'], {
+      get() {
+        return 'hello world'
+      },
+    })
+    expect(target['a.b.c']['e.d.f']).toEqual('hello world')
   })
 })

--- a/test/utils/parseModelDefinition.test.ts
+++ b/test/utils/parseModelDefinition.test.ts
@@ -17,8 +17,8 @@ it('parses a plain model definition', () => {
 
   expect(result).toEqual({
     primaryKey: 'id',
-    properties: ['id', 'firstName'],
-    relations: {},
+    properties: [['id'], ['firstName']],
+    relations: [],
   } as ParsedModelDefinition)
 })
 
@@ -41,20 +41,26 @@ it('parses a model definition with relations', () => {
 
   expect(result).toEqual({
     primaryKey: 'id',
-    properties: ['id', 'firstName'],
-    relations: {
-      country: new Relation({
-        to: 'country',
-        kind: RelationKind.OneOf,
-        attributes: {
-          unique: true,
-        },
-      }),
-      posts: new Relation({
-        to: 'post',
-        kind: RelationKind.ManyOf,
-      }),
-    },
+    properties: [['id'], ['firstName']],
+    relations: [
+      {
+        path: ['country'],
+        relation: new Relation({
+          to: 'country',
+          kind: RelationKind.OneOf,
+          attributes: {
+            unique: true,
+          },
+        }),
+      },
+      {
+        path: ['posts'],
+        relation: new Relation({
+          to: 'post',
+          kind: RelationKind.ManyOf,
+        }),
+      },
+    ],
   } as ParsedModelDefinition)
 })
 
@@ -85,20 +91,30 @@ it('parses a model definition with nested objects', () => {
 
   expect(result).toEqual({
     primaryKey: 'id',
-    properties: ['id', 'address.billing.street', 'address.billing.houseNumber'],
-    relations: {
-      'address.billing.country': new Relation({
-        to: 'country',
-        kind: RelationKind.OneOf,
-      }),
-      'activity.posts': new Relation({
-        to: 'post',
-        kind: RelationKind.ManyOf,
-        attributes: {
-          unique: true,
-        },
-      }),
-    },
+    properties: [
+      ['id'],
+      ['address', 'billing', 'street'],
+      ['address', 'billing', 'houseNumber'],
+    ],
+    relations: [
+      {
+        path: ['address', 'billing', 'country'],
+        relation: new Relation({
+          to: 'country',
+          kind: RelationKind.OneOf,
+        }),
+      },
+      {
+        path: ['activity', 'posts'],
+        relation: new Relation({
+          to: 'post',
+          kind: RelationKind.ManyOf,
+          attributes: {
+            unique: true,
+          },
+        }),
+      },
+    ],
   } as ParsedModelDefinition)
 })
 

--- a/test/utils/parseModelDefinition.test.ts
+++ b/test/utils/parseModelDefinition.test.ts
@@ -44,7 +44,7 @@ it('parses a model definition with relations', () => {
     properties: [['id'], ['firstName']],
     relations: [
       {
-        path: ['country'],
+        propertyPath: ['country'],
         relation: new Relation({
           to: 'country',
           kind: RelationKind.OneOf,
@@ -54,7 +54,7 @@ it('parses a model definition with relations', () => {
         }),
       },
       {
-        path: ['posts'],
+        propertyPath: ['posts'],
         relation: new Relation({
           to: 'post',
           kind: RelationKind.ManyOf,
@@ -98,14 +98,14 @@ it('parses a model definition with nested objects', () => {
     ],
     relations: [
       {
-        path: ['address', 'billing', 'country'],
+        propertyPath: ['address', 'billing', 'country'],
         relation: new Relation({
           to: 'country',
           kind: RelationKind.OneOf,
         }),
       },
       {
-        path: ['activity', 'posts'],
+        propertyPath: ['activity', 'posts'],
         relation: new Relation({
           to: 'post',
           kind: RelationKind.ManyOf,


### PR DESCRIPTION
This PR moves the internal representation of property paths from dot notation strings to arrays of strings.
This allows us to continue using and benefitting from `lodash/set`, and also support dots in model properties, eg:

```ts
export const db = factory({
  user: {
    'employee.id': primaryKey(() => 'abc-123'),
  }
})
```

Closes #149 