### PR TITLE
fix(types): relationships can be undefined

### DIFF
--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -199,13 +199,13 @@ export type Value<
     : // Extract value type from OneOf relations.
     Target[Key] extends OneOf<infer ModelName, infer Nullable>
     ? Nullable extends true
-      ? PublicEntity<Dictionary, ModelName> | null
-      : PublicEntity<Dictionary, ModelName>
+      ? PublicEntity<Dictionary, ModelName> | undefined | null
+      : PublicEntity<Dictionary, ModelName> | undefined
     : // Extract value type from ManyOf relations.
     Target[Key] extends ManyOf<infer ModelName, infer Nullable>
     ? Nullable extends true
-      ? PublicEntity<Dictionary, ModelName>[] | null
-      : PublicEntity<Dictionary, ModelName>[]
+      ? PublicEntity<Dictionary, ModelName>[] | undefined | null
+      : PublicEntity<Dictionary, ModelName>[] | undefined
     : // Account for primitive value getters because
     // native constructors (i.e. StringConstructor) satisfy
     // the "AnyObject" predicate below.

--- a/test/model/getAll.test-d.ts
+++ b/test/model/getAll.test-d.ts
@@ -24,10 +24,13 @@ allUsers[0].firstName
 allUsers[0].address.billing?.country
 
 // Relational properties.
-allUsers[0].posts[0].id
-allUsers[0].posts[0].title
+const user = allUsers[0];
+const { posts = [] } = user;
+posts[0].id
+posts[0].title
+
 // @ts-expect-error Property "unknown" doesn't exist on "post".
-allUsers[0].posts[0].unknown
+posts[0].unknown
 
 // @ts-expect-error Property "unknown" doesn't exist on "user".
 allUsers[0].unknown

--- a/test/model/relationalProperties.test-d.ts
+++ b/test/model/relationalProperties.test-d.ts
@@ -1,0 +1,21 @@
+import { factory, manyOf, oneOf, primaryKey } from '@mswjs/data'
+
+const db = factory({
+  user: {
+    id: primaryKey(String),
+    posts: manyOf('post'),
+  },
+  post: {
+    id: primaryKey(String),
+    author: oneOf('user'),
+  },
+})
+
+const user = db.user.create()
+const post = db.post.create()
+
+// @ts-expect-error author is potentially undefined
+post.author.id
+
+// @ts-expect-error posts is potentially undefined
+user.posts[0]

--- a/test/query/pagination.test.ts
+++ b/test/query/pagination.test.ts
@@ -323,7 +323,7 @@ test('supports sorting by both direct and relational properties in the paginated
     ],
   })
   const firstPageBooks = firstPage.map((book) => book.title)
-  const firstPageAuthors = firstPage.map((book) => book.author.firstName)
+  const firstPageAuthors = firstPage.map((book) => book.author?.firstName)
   expect(firstPageBooks).toEqual(['A', 'A'])
   expect(firstPageAuthors).toEqual(['John', 'Nelson'])
 })

--- a/test/relations/one-to-many.test.ts
+++ b/test/relations/one-to-many.test.ts
@@ -131,7 +131,7 @@ test('supports updating a recursive one-to-many relation', () => {
   })!
 
   expect(updatedJohn.friends).toHaveLength(1)
-  expect(updatedJohn.friends![0]).toHaveProperty('firstName', 'Kate')
+  expect(updatedJohn.friends![0]?.firstName).toEqual('Kate')
 })
 
 test('supports updating a recursive nullable one-to-many relation', () => {
@@ -173,7 +173,7 @@ test('supports updating a recursive nullable one-to-many relation', () => {
   })!
 
   expect(updatedJohn.friends).toHaveLength(1)
-  expect(updatedJohn.friends?.shift()).toHaveProperty('firstName', 'Kate')
+  expect(updatedJohn.friends?.shift()?.firstName).toEqual('Kate')
 
   const jack = db.user.create({
     id: 'jack',
@@ -196,7 +196,7 @@ test('supports updating a recursive nullable one-to-many relation', () => {
   })!
 
   expect(updatedJack.friends).toHaveLength(1)
-  expect(updatedJack.friends?.shift()).toHaveProperty('firstName', 'John')
+  expect(updatedJack.friends?.shift()?.firstName).toEqual('John')
 })
 
 test('supports querying through one-to-many relation', () => {

--- a/test/relations/one-to-many.test.ts
+++ b/test/relations/one-to-many.test.ts
@@ -131,7 +131,7 @@ test('supports updating a recursive one-to-many relation', () => {
   })!
 
   expect(updatedJohn.friends).toHaveLength(1)
-  expect(updatedJohn.friends[0]).toHaveProperty('firstName', 'Kate')
+  expect(updatedJohn.friends![0]).toHaveProperty('firstName', 'Kate')
 })
 
 test('supports updating a recursive nullable one-to-many relation', () => {

--- a/test/relations/one-to-one.test.ts
+++ b/test/relations/one-to-one.test.ts
@@ -921,10 +921,10 @@ test('preserves relational property getter after updating the parent entity', ()
   expect(Object.getOwnPropertyDescriptor(segment, 'revision')).toHaveProperty(
     'get',
   )
-  expect(segment.revision.id).toEqual('revision-1')
+  expect(segment.revision?.id).toEqual('revision-1')
 
   db.revision.update({
-    where: { id: { equals: segment.revision.id } },
+    where: { id: { equals: segment.revision?.id } },
     data: {
       title: 'Updated revision',
     },
@@ -932,7 +932,7 @@ test('preserves relational property getter after updating the parent entity', ()
 
   // Referencing the relational property on the updated parent
   // must resolve the latest referenced value (via getter).
-  expect(segment.revision.title).toEqual('Updated revision')
+  expect(segment.revision?.title).toEqual('Updated revision')
 })
 
 test('preserves nested relational properties after updating the parent entity', () => {

--- a/test/typings/relations.test-d.ts
+++ b/test/typings/relations.test-d.ts
@@ -18,7 +18,7 @@ const db = factory({
 })
 
 const user = db.user.create()
-user.country.code.toUpperCase()
+user.country?.code.toUpperCase()
 
 // @ts-expect-error Unknown property "foo" on "country".
 user.country.foo


### PR DESCRIPTION
When a model is created any property that does not have an initial value uses the factory method to create one. Since the factories are typed to only allow certain primitive values it is not possible for those values to ever be `undefined`. For relational properties created through `oneOf` and `manyOf` this is not the case however, if they are not provided an initial value they are `undefined`.

For example in the following snippet:
```typescript
const db = factory({
  user: {
    id: primaryKey(String),
  },
  post: {
    id: primaryKey(String),
    author: oneOf('user'),
  },
})

const post = db.user.create();
```
`post.author` is `undefined` but it is not included in the property type.

This PR adds `undefined` to the possible value types for relationships.