### PR TITLE
chore(ci): add "versions" step to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,14 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      # Versions
+      - name: Environment (versions)
+        run: |
+          echo "node: $(node -v)"
+          echo "npm: $(npm -v)"
+          echo "typescript: $(npm ls typescript)"
+          echo "tsc: $(tsc -v)"
+
       # Build
       - name: Build
         run: yarn build


### PR DESCRIPTION
This should help in observability of the local/CI environments differences. 