### PR TITLE
fix(executeQuery): support circular references when updating entities

### DIFF
--- a/src/query/executeQuery.ts
+++ b/src/query/executeQuery.ts
@@ -11,6 +11,7 @@ import { paginateResults } from './paginateResults'
 import { Database } from '../db/Database'
 import { sortResults } from './sortResults'
 import { invariant } from 'outvariant'
+import { safeStringify } from '../utils/safeStringify'
 
 const log = debug('executeQuery')
 
@@ -50,7 +51,7 @@ export function executeQuery(
   query: WeakQuerySelector<any> & BulkQueryOptions<any>,
   db: Database<any>,
 ): Entity<any, any>[] {
-  log(`${JSON.stringify(query)} on "${modelName}"`)
+  log(`${safeStringify(query)} on "${modelName}"`)
   log('using primary key "%s"', primaryKey)
 
   const records = db.getModel(modelName)
@@ -74,7 +75,7 @@ export function executeQuery(
   const resultJson = Array.from(result.values())
 
   log(
-    `resolved query "${JSON.stringify(query)}" on "${modelName}" to`,
+    `resolved query "${safeStringify(query)}" on "${modelName}" to`,
     resultJson,
   )
 

--- a/src/utils/safeStringify.ts
+++ b/src/utils/safeStringify.ts
@@ -1,0 +1,22 @@
+import { ENTITY_TYPE, PRIMARY_KEY } from '../glossary'
+
+export function safeStringify(value: any) {
+  const seen = new WeakSet()
+
+  return JSON.stringify(value, (_, value) => {
+    if (typeof value !== 'object' || value === null) {
+      return value
+    }
+
+    if (seen.has(value)) {
+      const type = value[ENTITY_TYPE]
+      const primaryKey = value[PRIMARY_KEY]
+      return type && primaryKey
+        ? `Entity(type: ${type}, ${primaryKey}: ${value[primaryKey]})`
+        : '[Circular Reference]'
+    }
+
+    seen.add(value)
+    return value
+  })
+}

--- a/src/utils/safeStringify.ts
+++ b/src/utils/safeStringify.ts
@@ -1,6 +1,6 @@
 import { ENTITY_TYPE, PRIMARY_KEY } from '../glossary'
 
-export function safeStringify(value: any) {
+export function safeStringify(value: unknown): string {
   const seen = new WeakSet()
 
   return JSON.stringify(value, (_, value) => {
@@ -11,6 +11,7 @@ export function safeStringify(value: any) {
     if (seen.has(value)) {
       const type = value[ENTITY_TYPE]
       const primaryKey = value[PRIMARY_KEY]
+
       return type && primaryKey
         ? `Entity(type: ${type}, ${primaryKey}: ${value[primaryKey]})`
         : '[Circular Reference]'

--- a/test/relations/bi-directional.test.ts
+++ b/test/relations/bi-directional.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @see https://github.com/mswjs/data/issues/139
+ */
 import { factory, manyOf, oneOf, primaryKey } from '@mswjs/data'
 
 test('supports creating a bi-directional one-to-one relationship', () => {
@@ -8,7 +11,7 @@ test('supports creating a bi-directional one-to-one relationship', () => {
     },
   })
 
-  // create bi-directional relationship between partners
+  // Create a bi-directional relationship between partners.
   const starsky = db.user.create({
     id: 'starsky',
   })
@@ -39,7 +42,7 @@ test('supports creating a bi-directional one-to-many relationship', () => {
     },
   })
 
-  // create bi-directional relationship between author and posts
+  // Create a bi-directional relationship between author and posts.
   const author = db.user.create({ id: 'user-1' })
   const posts = [
     db.post.create({
@@ -61,7 +64,7 @@ test('supports creating a bi-directional one-to-many relationship', () => {
 
   posts.forEach((post) => {
     expect(post.author).toBe(nextAuthor)
-    expect(nextAuthor.posts.includes(post)).toBe(true)
+    expect(nextAuthor.posts?.includes(post)).toBe(true)
   })
 })
 
@@ -78,7 +81,7 @@ test('supports creating a bi-directional many-to-many relationship', () => {
     },
   })
 
-  // create bi-directional relationship between authors and posts
+  // Create a bi-directional relationship between authors and posts.
   const authors = [
     db.user.create({ id: 'user-1' }),
     db.user.create({ id: 'user-2' }),
@@ -104,8 +107,8 @@ test('supports creating a bi-directional many-to-many relationship', () => {
   expect(nextAuthors).toHaveLength(authors.length)
   posts.forEach((post) => {
     nextAuthors.forEach((author) => {
-      expect(post.authors.includes(author)).toBe(true)
-      expect(author.posts.includes(post)).toBe(true)
+      expect(post.authors?.includes(author)).toBe(true)
+      expect(author.posts?.includes(post)).toBe(true)
     })
   })
 })
@@ -118,7 +121,7 @@ test('supports querying by a bi-directional one-to-one relationship', () => {
     },
   })
 
-  // create bi-directional relationship between partners
+  // Create a bi-directional relationship between partners
   const starsky = db.user.create({
     id: 'starsky',
   })
@@ -132,10 +135,10 @@ test('supports querying by a bi-directional one-to-one relationship', () => {
     strict: true,
   })!
 
-  // create unrelated user to ensure they are not found
+  // Create an unrelated user to ensure they are not found
   db.user.create({ id: 'user' })
 
-  // can find models using bi-directional relationship
+  // Can find models using bi-directional relationship
   const starskysPartner = db.user.findFirst({
     where: { partner: { id: { equals: starsky.id } } },
     strict: true,
@@ -157,7 +160,7 @@ test('supports querying by a bi-directional one-to-many relationship', () => {
     },
   })
 
-  // create bi-directional relationship between author and posts
+  // Create a bi-directional relationship between author and posts
   const firstAuthor = db.user.create({ id: 'user-1' })
   const secondAuthor = db.user.create({ id: 'user-2' })
   const thirdAuthor = db.user.create({ id: 'user-3' })
@@ -198,11 +201,11 @@ test('supports querying by a bi-directional one-to-many relationship', () => {
     strict: true,
   })
 
-  // create unrelated user and post to ensure they are not included
+  // Create unrelated user and post to ensure they are not included.
   db.user.create({ id: 'user-unrelated' })
   db.post.create({ id: 'post-unrelated' })
 
-  // find posts in one-to-many direction
+  // Find posts in one-to-many direction
   const posts = db.post.findMany({
     where: { author: { id: { in: [firstAuthor.id, secondAuthor.id] } } },
     strict: true,
@@ -215,7 +218,7 @@ test('supports querying by a bi-directional one-to-many relationship', () => {
     expect(posts.includes(expectedPost)).toBe(true)
   })
 
-  // find authors in many-to-one direction
+  // Find authors in many-to-one direction.
   const authors = db.user.findMany({
     where: { posts: { id: { in: [secondPost.id, thirdPost.id] } } },
     strict: true,
@@ -242,7 +245,7 @@ test('supports querying by a bi-directional many-to-many relationship', () => {
     },
   })
 
-  // create bi-directional relationship between authors and posts
+  // Create a bi-directional relationship between authors and posts.
   const firstAuthor = db.user.create({ id: 'user-1' })
   const secondAuthor = db.user.create({ id: 'user-2' })
   const thirdAuthor = db.user.create({ id: 'user-3' })
@@ -283,7 +286,7 @@ test('supports querying by a bi-directional many-to-many relationship', () => {
     strict: true,
   })
 
-  // find posts through many-to-many relationship
+  // Find posts through many-to-many relationship.
   const posts = db.post.findMany({
     where: { authors: { id: { in: [firstAuthor.id, secondAuthor.id] } } },
     strict: true,
@@ -305,7 +308,7 @@ test('supports updating using an entity with a bi-directional one-to-one relatio
     },
   })
 
-  // create bi-directional relationship between partners
+  // Create a bi-directional relationship between partners.
   const hutch = db.user.create({
     id: 'hutch',
     partner: db.user.create({
@@ -318,10 +321,10 @@ test('supports updating using an entity with a bi-directional one-to-one relatio
     strict: true,
   })!
 
-  // create a user that is not related to starsky or hutch.
+  // Create a user that is not related to starsky or hutch.
   db.user.create({ id: 'user' })
 
-  // update using user with bi-directional relationship
+  // Update using user with bi-directional relationship.
   const user = db.user.update({
     where: { id: { equals: 'user' } },
     data: { partner: starsky },
@@ -344,7 +347,7 @@ test('supports updating using an entity with a bi-directional one-to-many relati
     },
   })
 
-  // create bi-directional relationship between author and posts
+  // Create a bi-directional relationship between author and posts.
   const author = db.user.create({
     id: 'user-1',
   })
@@ -366,13 +369,13 @@ test('supports updating using an entity with a bi-directional one-to-many relati
     strict: true,
   })!
 
-  // create a post that is not related to author
+  // Create a post that is not related to author.
   db.post.create({
     id: 'post-3',
     title: 'Third post',
   })
 
-  // update post using author with bi-directional relationship
+  // Update post using author with bi-directional relationship.
   const post = db.post.update({
     where: { id: { equals: 'post-3' } },
     data: { author: nextAuthor },
@@ -395,7 +398,7 @@ test('supports updating using an entity with a bi-directional many-to-many relat
     },
   })
 
-  // create bi-directional relationship between authors and posts
+  // Create a bi-directional relationship between authors and posts.
   const authors = [
     db.user.create({
       id: 'user-1',
@@ -422,12 +425,12 @@ test('supports updating using an entity with a bi-directional many-to-many relat
     strict: true,
   })!
 
-  // create an unrelated post
+  // Create an unrelated post.
   db.post.create({
     id: 'post-3',
   })
 
-  // update post using authors with bi-directional relationships
+  // Update post using authors with bi-directional relationships.
   const post = db.post.update({
     where: { id: { equals: 'post-2' } },
     data: { authors: nextAuthors },
@@ -435,7 +438,7 @@ test('supports updating using an entity with a bi-directional many-to-many relat
   })!
 
   expect(post.authors).toHaveLength(authors.length)
-  post.authors.forEach((author, i) => {
+  post.authors?.forEach((author, i) => {
     expect(author).toBe(nextAuthors[i])
   })
 })

--- a/test/relations/bi-directional.test.ts
+++ b/test/relations/bi-directional.test.ts
@@ -1,0 +1,441 @@
+import { factory, manyOf, oneOf, primaryKey } from '@mswjs/data'
+
+test('supports creating a bi-directional one-to-one relationship', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(String),
+      partner: oneOf('user'),
+    },
+  })
+
+  // create bi-directional relationship between partners
+  const starsky = db.user.create({
+    id: 'starsky',
+  })
+  const hutch = db.user.create({
+    id: 'hutch',
+    partner: starsky,
+  })
+  const nextStarsky = db.user.update({
+    where: { id: { equals: starsky.id } },
+    data: { partner: hutch },
+    strict: true,
+  })!
+
+  expect(hutch.partner).toBe(nextStarsky)
+  expect(nextStarsky.partner).toBe(hutch)
+})
+
+test('supports creating a bi-directional one-to-many relationship', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(String),
+      posts: manyOf('post'),
+    },
+    post: {
+      id: primaryKey(String),
+      title: String,
+      author: oneOf('user'),
+    },
+  })
+
+  // create bi-directional relationship between author and posts
+  const author = db.user.create({ id: 'user-1' })
+  const posts = [
+    db.post.create({
+      id: 'post-1',
+      title: 'First post',
+      author,
+    }),
+    db.post.create({
+      id: 'post-2',
+      title: 'Second post',
+      author,
+    }),
+  ]
+  const nextAuthor = db.user.update({
+    where: { id: { equals: author.id } },
+    data: { posts },
+    strict: true,
+  })!
+
+  posts.forEach((post) => {
+    expect(post.author).toBe(nextAuthor)
+    expect(nextAuthor.posts.includes(post)).toBe(true)
+  })
+})
+
+test('supports creating a bi-directional many-to-many relationship', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(String),
+      posts: manyOf('post'),
+    },
+    post: {
+      id: primaryKey(String),
+      title: String,
+      authors: manyOf('user'),
+    },
+  })
+
+  // create bi-directional relationship between authors and posts
+  const authors = [
+    db.user.create({ id: 'user-1' }),
+    db.user.create({ id: 'user-2' }),
+  ]
+  const posts = [
+    db.post.create({
+      id: 'post-1',
+      title: 'First post',
+      authors,
+    }),
+    db.post.create({
+      id: 'post-2',
+      title: 'Second post',
+      authors,
+    }),
+  ]
+  const nextAuthors = db.user.updateMany({
+    where: { id: { in: authors.map(({ id }) => id) } },
+    data: { posts },
+    strict: true,
+  })!
+
+  expect(nextAuthors).toHaveLength(authors.length)
+  posts.forEach((post) => {
+    nextAuthors.forEach((author) => {
+      expect(post.authors.includes(author)).toBe(true)
+      expect(author.posts.includes(post)).toBe(true)
+    })
+  })
+})
+
+test('supports querying by a bi-directional one-to-one relationship', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(String),
+      partner: oneOf('user'),
+    },
+  })
+
+  // create bi-directional relationship between partners
+  const starsky = db.user.create({
+    id: 'starsky',
+  })
+  const hutch = db.user.create({
+    id: 'hutch',
+    partner: starsky,
+  })
+  db.user.update({
+    where: { id: { equals: starsky.id } },
+    data: { partner: hutch },
+    strict: true,
+  })!
+
+  // create unrelated user to ensure they are not found
+  db.user.create({ id: 'user' })
+
+  // can find models using bi-directional relationship
+  const starskysPartner = db.user.findFirst({
+    where: { partner: { id: { equals: starsky.id } } },
+    strict: true,
+  })
+
+  expect(starskysPartner).toBe(hutch)
+})
+
+test('supports querying by a bi-directional one-to-many relationship', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(String),
+      posts: manyOf('post'),
+    },
+    post: {
+      id: primaryKey(String),
+      title: String,
+      author: oneOf('user'),
+    },
+  })
+
+  // create bi-directional relationship between author and posts
+  const firstAuthor = db.user.create({ id: 'user-1' })
+  const secondAuthor = db.user.create({ id: 'user-2' })
+  const thirdAuthor = db.user.create({ id: 'user-3' })
+
+  const firstPost = db.post.create({
+    id: 'post-1',
+    title: 'First post',
+    author: firstAuthor,
+  })
+  const secondPost = db.post.create({
+    id: 'post-2',
+    title: 'Second post',
+    author: firstAuthor,
+  })
+  const thirdPost = db.post.create({
+    id: 'post-3',
+    title: 'Third post',
+    author: secondAuthor,
+  })
+  const fourthPost = db.post.create({
+    id: 'post-4',
+    title: 'Fourth post',
+    author: thirdAuthor,
+  })
+  const nextFirstAuthor = db.user.update({
+    where: { id: { equals: firstAuthor.id } },
+    data: { posts: [firstPost, secondPost] },
+    strict: true,
+  })!
+  const nextSecondAuthor = db.user.update({
+    where: { id: { equals: secondAuthor.id } },
+    data: { posts: [thirdPost] },
+    strict: true,
+  })!
+  db.user.update({
+    where: { id: { equals: thirdAuthor.id } },
+    data: { posts: [fourthPost] },
+    strict: true,
+  })
+
+  // create unrelated user and post to ensure they are not included
+  db.user.create({ id: 'user-unrelated' })
+  db.post.create({ id: 'post-unrelated' })
+
+  // find posts in one-to-many direction
+  const posts = db.post.findMany({
+    where: { author: { id: { in: [firstAuthor.id, secondAuthor.id] } } },
+    strict: true,
+  })!
+
+  const expectedPosts = [firstPost, secondPost, thirdPost]
+  expect(posts).toHaveLength(expectedPosts.length)
+
+  expectedPosts.forEach((expectedPost) => {
+    expect(posts.includes(expectedPost)).toBe(true)
+  })
+
+  // find authors in many-to-one direction
+  const authors = db.user.findMany({
+    where: { posts: { id: { in: [secondPost.id, thirdPost.id] } } },
+    strict: true,
+  })!
+
+  const expectedAuthors = [nextFirstAuthor, nextSecondAuthor]
+  expect(authors).toHaveLength(expectedAuthors.length)
+
+  expectedAuthors.forEach((expectedAuthor) => {
+    expect(authors.includes(expectedAuthor)).toBe(true)
+  })
+})
+
+test('supports querying by a bi-directional many-to-many relationship', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(String),
+      posts: manyOf('post'),
+    },
+    post: {
+      id: primaryKey(String),
+      title: String,
+      authors: manyOf('user'),
+    },
+  })
+
+  // create bi-directional relationship between authors and posts
+  const firstAuthor = db.user.create({ id: 'user-1' })
+  const secondAuthor = db.user.create({ id: 'user-2' })
+  const thirdAuthor = db.user.create({ id: 'user-3' })
+
+  const firstPost = db.post.create({
+    id: 'post-1',
+    title: 'First post',
+    authors: [firstAuthor],
+  })
+  const secondPost = db.post.create({
+    id: 'post-2',
+    title: 'Second post',
+    authors: [firstAuthor, secondAuthor],
+  })
+  const thirdPost = db.post.create({
+    id: 'post-3',
+    title: 'Third post',
+    authors: [secondAuthor, thirdAuthor],
+  })
+  const fourthPost = db.post.create({
+    id: 'post-4',
+    title: 'Fourth post',
+    authors: [thirdAuthor],
+  })
+  db.user.update({
+    where: { id: { equals: firstAuthor.id } },
+    data: { posts: [firstPost, secondPost] },
+    strict: true,
+  })
+  db.user.update({
+    where: { id: { equals: secondAuthor.id } },
+    data: { posts: [thirdPost] },
+    strict: true,
+  })
+  db.user.update({
+    where: { id: { equals: thirdAuthor.id } },
+    data: { posts: [fourthPost] },
+    strict: true,
+  })
+
+  // find posts through many-to-many relationship
+  const posts = db.post.findMany({
+    where: { authors: { id: { in: [firstAuthor.id, secondAuthor.id] } } },
+    strict: true,
+  })
+
+  const expectedPosts = [firstPost, secondPost, thirdPost]
+  expect(posts).toHaveLength(expectedPosts.length)
+
+  expectedPosts.forEach((expectedPost) => {
+    expect(posts.includes(expectedPost)).toBe(true)
+  })
+})
+
+test('supports updating using an entity with a bi-directional one-to-one relation', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(String),
+      partner: oneOf('user'),
+    },
+  })
+
+  // create bi-directional relationship between partners
+  const hutch = db.user.create({
+    id: 'hutch',
+    partner: db.user.create({
+      id: 'starsky',
+    }),
+  })
+  const starsky = db.user.update({
+    where: { id: { equals: 'starsky' } },
+    data: { partner: hutch },
+    strict: true,
+  })!
+
+  // create a user that is not related to starsky or hutch.
+  db.user.create({ id: 'user' })
+
+  // update using user with bi-directional relationship
+  const user = db.user.update({
+    where: { id: { equals: 'user' } },
+    data: { partner: starsky },
+    strict: true,
+  })!
+
+  expect(user.partner).toBe(starsky)
+})
+
+test('supports updating using an entity with a bi-directional one-to-many relationship', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(String),
+      posts: manyOf('post'),
+    },
+    post: {
+      id: primaryKey(String),
+      title: String,
+      author: oneOf('user'),
+    },
+  })
+
+  // create bi-directional relationship between author and posts
+  const author = db.user.create({
+    id: 'user-1',
+  })
+  const posts = [
+    db.post.create({
+      id: 'post-1',
+      title: 'First post',
+      author,
+    }),
+    db.post.create({
+      id: 'post-2',
+      title: 'Second post',
+      author,
+    }),
+  ]
+  const nextAuthor = db.user.update({
+    where: { id: { equals: author.id } },
+    data: { posts },
+    strict: true,
+  })!
+
+  // create a post that is not related to author
+  db.post.create({
+    id: 'post-3',
+    title: 'Third post',
+  })
+
+  // update post using author with bi-directional relationship
+  const post = db.post.update({
+    where: { id: { equals: 'post-3' } },
+    data: { author: nextAuthor },
+    strict: true,
+  })!
+
+  expect(post.author).toBe(nextAuthor)
+})
+
+test('supports updating using an entity with a bi-directional many-to-many relation', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(String),
+      posts: manyOf('post'),
+    },
+    post: {
+      id: primaryKey(String),
+      title: String,
+      authors: manyOf('user'),
+    },
+  })
+
+  // create bi-directional relationship between authors and posts
+  const authors = [
+    db.user.create({
+      id: 'user-1',
+    }),
+    db.user.create({
+      id: 'user-2',
+    }),
+  ]
+  const posts = [
+    db.post.create({
+      id: 'post-1',
+      title: 'First post',
+      authors,
+    }),
+    db.post.create({
+      id: 'post-2',
+      title: 'Second post',
+      authors,
+    }),
+  ]
+  const nextAuthors = db.user.updateMany({
+    where: { id: { in: authors.map((author) => author.id) } },
+    data: { posts },
+    strict: true,
+  })!
+
+  // create an unrelated post
+  db.post.create({
+    id: 'post-3',
+  })
+
+  // update post using authors with bi-directional relationships
+  const post = db.post.update({
+    where: { id: { equals: 'post-2' } },
+    data: { authors: nextAuthors },
+    strict: true,
+  })!
+
+  expect(post.authors).toHaveLength(authors.length)
+  post.authors.forEach((author, i) => {
+    expect(author).toBe(nextAuthors[i])
+  })
+})


### PR DESCRIPTION
closes #139 

When passing an object with circular references to `update` the `executeQuery` function fails: it passes the `query` object to `JSON.stringify` which throws a "cyclic object value" exception.

Circular references are created when a bi-directional relationship is made. For example:

```typescript
const db = factory({
  user: {
    id: primaryKey(String),
    posts: manyOf('post'),
  },
  post: {
    id: primaryKey(String),
    author: oneOf('user')
  },
});

const author = db.user.create({ id: 'user-1' })
const post = db.post.create({ id: 'post-1', author })
const nextAuthor = db.user.update({
  where: { id: { equals: author.id } },
  data: { posts: [post] },
})
```

If an entity that has been set up this way is passed to `update` it fails because of the above:
```typescript
db.post.update({
  where: { id: { equals: 'a-different-post' } },
  data: { author: nextAuthor },
});
```

As @tinleym talked about in #139, to mock some GraphQL responses these relationships need to be traversed in both directions. This makes these bi-directional setups required to properly mock those resolvers.

This PR adds tests for creating / using bi-directional relationships and fixes the error thrown by `executeQuery` by adding a `safeStringify` util that is used in place of `JSON.stringify`.

The `safeStringify` util replaces any circular references with a string representation instead. It's more or less a knock off of the [one from the MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cyclic_object_value), but it also inserts some information about the entity it's replaced to keep the logs useful.

The stringified version of `nextAuthor` that would produced by `safeStringify` is:
```javascript
{ "id": "user-1", "posts": [{ "id": "post-1", "author": "Entity(type: user, id: user-1)" }] }
```


