### PR TITLE
fix(create): allow the field with type array to be an array of objects

### DIFF
--- a/src/utils/isModelValueType.ts
+++ b/src/utils/isModelValueType.ts
@@ -10,8 +10,5 @@ function isPrimitiveValueType(value: any): value is PrimitiveValueType {
 }
 
 export function isModelValueType(value: any): value is ModelValueType {
-  return (
-    isPrimitiveValueType(value) ||
-    (Array.isArray(value) && value.every(isPrimitiveValueType))
-  )
+  return isPrimitiveValueType(value) || Array.isArray(value)
 }

--- a/test/model/create.test.ts
+++ b/test/model/create.test.ts
@@ -13,7 +13,7 @@ test('creates a new entity', () => {
   // Without any arguments a new entity is seeded
   // using the value getters defined in the model.
   const randomUser = db.user.create()
-  expect(randomUser).toHaveProperty('id', userId)
+  expect(randomUser.id).toEqual(userId)
 })
 
 test('creates a new entity with initial values', () => {
@@ -27,23 +27,23 @@ test('creates a new entity with initial values', () => {
   const exactUser = db.user.create({
     id: 'abc-123',
   })
-  expect(exactUser).toHaveProperty('id', 'abc-123')
+  expect(exactUser.id).toEqual('abc-123')
 })
 
 test('creates a new entity with an array property', () => {
   const db = factory({
     user: {
       id: primaryKey(datatype.uuid),
-      arrayProp: Array,
+      favouriteNumbers: Array,
     },
   })
 
   const exactUser = db.user.create({
     id: 'abc-123',
-    arrayProp: [1, 2, 3],
+    favouriteNumbers: [1, 2, 3],
   })
-  expect(exactUser).toHaveProperty('id', 'abc-123')
-  expect(exactUser).toHaveProperty('arrayProp', [1, 2, 3])
+  expect(exactUser.id).toEqual('abc-123')
+  expect(exactUser.favouriteNumbers).toEqual([1, 2, 3])
 })
 
 test('creates a new entity with an array property with array of objects assigned', () => {
@@ -70,8 +70,8 @@ test('creates a new entity with an array property with array of objects assigned
     notes: exampleNotes,
   })
 
-  expect(exactUser).toHaveProperty('id', 'abc-123')
-  expect(exactUser).toHaveProperty('notes', exampleNotes)
+  expect(exactUser.id).toEqual('abc-123')
+  expect(exactUser.notes).toEqual(exampleNotes)
 })
 
 test('creates a new entity with nullable properties', () => {
@@ -92,9 +92,9 @@ test('creates a new entity with nullable properties', () => {
     name: null,
   })
 
-  expect(user).toHaveProperty('name', null)
-  expect(user).toHaveProperty('age', null)
-  expect(user.address).toHaveProperty('number', null)
+  expect(user.name).toEqual(null)
+  expect(user.age).toEqual(null)
+  expect(user.address.number).toEqual(null)
 })
 
 test('supports nested objects in the model definition', () => {
@@ -128,9 +128,9 @@ test('supports nested objects in the model definition', () => {
     },
   })
 
-  expect(exactUser).toHaveProperty('id', 'abc-123')
-  expect(exactUser).toHaveProperty('name', 'sampleUser')
-  expect(exactUser).toHaveProperty('info', {
+  expect(exactUser.id).toEqual('abc-123')
+  expect(exactUser.name).toEqual('sampleUser')
+  expect(exactUser.info).toEqual({
     firstName: 'Reginald',
     lastName: 'Dwight',
     address: {
@@ -171,10 +171,12 @@ test('relational properties can be declared in nested objects', () => {
     },
   })
 
-  expect(exactUser).toHaveProperty('name', 'user')
-  expect(exactUser.info).toHaveProperty('firstName', 'Ryuichi')
-  expect(exactUser.info).toHaveProperty('lastName', 'Sakamoto')
-  expect(exactUser.info.country).toHaveProperty('name', 'Japan')
+  expect(exactUser.name).toEqual('user')
+  expect(exactUser.info.firstName).toEqual('Ryuichi')
+  expect(exactUser.info.lastName).toEqual('Sakamoto')
+  expect(exactUser.info.country).toEqual(
+    expect.objectContaining({ name: 'Japan' }),
+  )
 })
 
 test('uses value getters when creating an entity with nested arrays', () => {
@@ -194,10 +196,10 @@ test('uses value getters when creating an entity with nested arrays', () => {
     name: 'sampleUser',
   })
 
-  expect(exactUser).toHaveProperty('name', 'sampleUser')
+  expect(exactUser.name).toEqual('sampleUser')
   expect(exactUser).toHaveProperty('info')
-  expect(exactUser.info).toHaveProperty('tags', [1, 2])
-  expect(exactUser.info).toHaveProperty('documents', [])
+  expect(exactUser.info.tags).toEqual([1, 2])
+  expect(exactUser.info.documents).toEqual([])
 })
 
 test('supports property names with dots in model definition', () => {
@@ -211,7 +213,7 @@ test('supports property names with dots in model definition', () => {
     'employee.id': 'abc-123',
   })
 
-  expect(user).toHaveProperty(['employee.id'], 'abc-123')
+  expect(user['employee.id']).toEqual('abc-123')
 })
 
 test('throws an exception when null used as initial value for non-nullable properties', () => {

--- a/test/model/create.test.ts
+++ b/test/model/create.test.ts
@@ -46,7 +46,7 @@ test('creates a new entity with an array property', () => {
   expect(exactUser).toHaveProperty('arrayProp', [1, 2, 3])
 })
 
-test('creates a new entity with an array property with aray of objects assigned', () => {
+test('creates a new entity with an array property with array of objects assigned', () => {
   const db = factory({
     user: {
       id: primaryKey(datatype.uuid),

--- a/test/model/create.test.ts
+++ b/test/model/create.test.ts
@@ -50,28 +50,28 @@ test('creates a new entity with an array property with array of objects assigned
   const db = factory({
     user: {
       id: primaryKey(datatype.uuid),
-      arrayProp: Array,
+      notes: Array,
     },
   })
 
-  const arrayOfObjects = [
+  const exampleNotes = [
     {
-      key: 'hobby',
-      value: 'code',
+      key: '001',
+      value: 'Buy groceries',
     },
     {
-      key: 'phone',
-      value: 12345,
+      key: '002',
+      value: 'Call grandpa on Friday',
     },
   ]
 
   const exactUser = db.user.create({
     id: 'abc-123',
-    arrayProp: arrayOfObjects,
+    notes: exampleNotes,
   })
 
   expect(exactUser).toHaveProperty('id', 'abc-123')
-  expect(exactUser).toHaveProperty('arrayProp', arrayOfObjects)
+  expect(exactUser).toHaveProperty('notes', exampleNotes)
 })
 
 test('creates a new entity with nullable properties', () => {

--- a/test/model/create.test.ts
+++ b/test/model/create.test.ts
@@ -46,6 +46,34 @@ test('creates a new entity with an array property', () => {
   expect(exactUser).toHaveProperty('arrayProp', [1, 2, 3])
 })
 
+test('creates a new entity with an array property with aray of objects assigned', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(datatype.uuid),
+      arrayProp: Array,
+    },
+  })
+
+  const arrayOfObjects = [
+    {
+      key: 'hobby',
+      value: 'code',
+    },
+    {
+      key: 'phone',
+      value: 12345,
+    },
+  ]
+
+  const exactUser = db.user.create({
+    id: 'abc-123',
+    arrayProp: arrayOfObjects,
+  })
+
+  expect(exactUser).toHaveProperty('id', 'abc-123')
+  expect(exactUser).toHaveProperty('arrayProp', arrayOfObjects)
+})
+
 test('creates a new entity with nullable properties', () => {
   const db = factory({
     user: {

--- a/test/utils/isModelValueType.test.ts
+++ b/test/utils/isModelValueType.test.ts
@@ -28,18 +28,18 @@ it('returns true given an array with primitive values', () => {
   expect(isModelValueType(['I am a string', 100])).toBe(true)
 })
 
+it('returns true when given an array with non-primitive values', () => {
+  expect(isModelValueType(['I am a string', {}])).toBe(true)
+})
+
+it('returns true when given nested primitive arrays', () => {
+  expect(isModelValueType(['I am a string', [100]])).toBe(true)
+})
+
 it('returns false given an undefined', () => {
   expect(isModelValueType(undefined)).toBe(false)
 })
 
 it('returns false given a null', () => {
   expect(isModelValueType(null)).toBe(false)
-})
-
-it('returns false when given an array with non-primitive values', () => {
-  expect(isModelValueType(['I am a string', {}])).toBe(false)
-})
-
-it('returns false when given nested primitive arrays', () => {
-  expect(isModelValueType(['I am a string', [100]])).toBe(false)
 })


### PR DESCRIPTION
- Fixes #165

I stumbled upon an issue mentioned in https://github.com/mswjs/data/issues/165 when using an array of objects for one of the fields of the model. After downgrading the version to v0.7.2 it worked fine. 

If it's a regression as mentioned in https://github.com/mswjs/data/issues/165#issuecomment-974645341, removing the additional check for primitive values in case of an array should suffice. However, I'm not sure if it could affect the feature of nullable properties from https://github.com/mswjs/data/pull/143.

I just started using the library and I'm not fully aware of some parts of it as well as the internals 😉  Let me know if I'm missing something. With some guidance, I believe I could fix that one 😄 

Btw. Huge thanks for maintaining `msw` and making the process of creating tests so nice!
