### PR TITLE
fix(types): annotate nested relationships

### DIFF
--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -213,7 +213,7 @@ export type Value<
     ? ReturnType<Target[Key]>
     : // Handle nested objects.
     Target[Key] extends AnyObject
-    ? Partial<Value<Target[Key], Target>>
+    ? Partial<Value<Target[Key], Dictionary>>
     : // Otherwise, return the return type of primitive value getters.
       ReturnType<Target[Key]>
 }

--- a/test/typings/relations.test-d.ts
+++ b/test/typings/relations.test-d.ts
@@ -1,0 +1,30 @@
+import { factory, oneOf, primaryKey } from '../../src'
+
+const db = factory({
+  user: {
+    id: primaryKey(String),
+    country: oneOf('country'),
+    stats: {
+      revision: oneOf('revision'),
+    },
+  },
+  country: {
+    code: primaryKey(String),
+  },
+  revision: {
+    id: primaryKey(String),
+    updatedAt: Number,
+  },
+})
+
+const user = db.user.create()
+user.country.code.toUpperCase()
+
+// @ts-expect-error Unknown property "foo" on "country".
+user.country.foo
+
+user.stats.revision?.id
+user.stats.revision?.updatedAt.toFixed()
+
+// @ts-expect-error Unknown property "foo" on "revision".
+user.stats.revision?.foo


### PR DESCRIPTION
## Current behavior

```ts
const db = factory({
  user: {
    id: primaryKey(String),
    country: oneOf('country'),
    stats: {
      revision: oneOf('revision'),
    },
  },
  country: {
    code: primaryKey(String),
  },
  revision: {
    id: primaryKey(String),
    updatedAt: Number,
  },
})

const user = db.user.create()
user.country.code.toUpperCase()

user.stats.revision?.id // TypeError
user.stats.revision?.updatedAt.toFixed() // TypeError
```

A nested relationship is not annotated because the `Value` generic for the nested properties passed the incorrect `Dictionary` generic:

https://github.com/mswjs/data/blob/0970e7ed5a9094d6618ed6563f8bb3a00d5c9ecc/src/glossary.ts#L216

This causes the `user.stats.revision` to be type of `Value<undefined, OneOf<...>>`. That `undefined` means that the relationship value cannot be inferred when using `PublicEntity` later on:

https://github.com/mswjs/data/blob/0970e7ed5a9094d6618ed6563f8bb3a00d5c9ecc/src/glossary.ts#L203

https://github.com/mswjs/data/blob/0970e7ed5a9094d6618ed6563f8bb3a00d5c9ecc/src/glossary.ts#L68

`Dictionary[ModelName]` yields `undefined`. 