### PR TITLE
fix(updateEntity): preserve relational getters when spreading "entityChunk"

### DIFF
--- a/src/model/updateEntity.ts
+++ b/src/model/updateEntity.ts
@@ -12,6 +12,7 @@ import {
 import { isObject } from '../utils/isObject'
 import { inheritInternalProperties } from '../utils/inheritInternalProperties'
 import { NullableProperty } from '../nullable'
+import { spread } from '../utils/spread'
 
 const log = debug('updateEntity')
 
@@ -117,22 +118,22 @@ export function updateEntity(
 
         return nextEntity
       },
-      { ...entityChunk },
+      spread(entityChunk),
     )
 
     return result
   }
 
-  const result = updateRecursively(entity, data)
+  const nextEntity = updateRecursively(entity, data)
 
   /**
    * @note Inherit the internal properties (type, primary key)
    * from the source (previous) entity.
    * Spreading the entity chunk strips off its symbols.
    */
-  inheritInternalProperties(result, entity)
+  inheritInternalProperties(nextEntity, entity)
 
-  log('successfully updated to:', result)
+  log('successfully updated to:', nextEntity)
 
-  return result
+  return nextEntity
 }

--- a/src/utils/spread.ts
+++ b/src/utils/spread.ts
@@ -1,0 +1,26 @@
+import { isObject } from './isObject'
+
+/**
+ * Clones the given object, preserving its setters/getters.
+ */
+export function spread<
+  ObjectType extends Record<string | number | symbol, unknown>,
+>(source: ObjectType): ObjectType {
+  const target = {} as ObjectType
+  const descriptors = Object.getOwnPropertyDescriptors(source)
+
+  for (const [propertyName, descriptor] of Object.entries(descriptors)) {
+    // Spread nested objects, preserving their descriptors.
+    if (isObject(descriptor.value)) {
+      Object.defineProperty(target, propertyName, {
+        ...descriptor,
+        value: spread(descriptor.value),
+      })
+      continue
+    }
+
+    Object.defineProperty(target, propertyName, descriptor)
+  }
+
+  return target
+}

--- a/test/utils/spread.test.ts
+++ b/test/utils/spread.test.ts
@@ -1,0 +1,42 @@
+import { spread } from '../../src/utils/spread'
+
+it('spreads a plain object', () => {
+  const source = { a: 1, b: { c: 2 } }
+  const target = spread(source)
+
+  expect(target).toEqual(source)
+
+  source.a = 2
+  source.b.c = 3
+
+  expect(target.a).toEqual(1)
+  expect(target.b.c).toEqual(2)
+})
+
+it('preserves property getters', () => {
+  const source = { a: 1, getCount: undefined }
+  Object.defineProperty(source, 'getCount', {
+    get() {
+      return 123
+    },
+  })
+
+  const target = spread(source)
+
+  expect(target.a).toEqual(1)
+  expect(Object.getOwnPropertyDescriptor(target, 'getCount')).toEqual(
+    Object.getOwnPropertyDescriptor(source, 'getCount'),
+  )
+  expect(target.getCount).toEqual(123)
+})
+
+it('does not preserve symbols', () => {
+  const symbol = Symbol('secret')
+  const source = {} as { [symbol]: number }
+  Object.defineProperty(source, symbol, { value: 123 })
+
+  const target = spread(source)
+
+  expect(target[symbol]).toBeUndefined()
+  expect(Object.getOwnPropertySymbols(target)).toEqual([])
+})


### PR DESCRIPTION
- Fixes #170
- Originated from #167 

## Changes

- Adds the `spread` utility that preserves object getters/setters.
- Adds missing integration tests to `one-to-one` relationship test suite. 