### PR TITLE
fix(types): nullable relations are never undefined

### DIFF
--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -213,12 +213,12 @@ export type Value<
     : // Extract value type from OneOf relations.
     Target[Key] extends OneOf<infer ModelName, infer Nullable>
     ? Nullable extends true
-      ? PublicEntity<Dictionary, ModelName> | undefined | null
+      ? PublicEntity<Dictionary, ModelName> | null
       : PublicEntity<Dictionary, ModelName> | undefined
     : // Extract value type from ManyOf relations.
     Target[Key] extends ManyOf<infer ModelName, infer Nullable>
     ? Nullable extends true
-      ? PublicEntity<Dictionary, ModelName>[] | undefined | null
+      ? PublicEntity<Dictionary, ModelName>[] | null
       : PublicEntity<Dictionary, ModelName>[] | undefined
     : // Account for primitive value getters because
     // native constructors (i.e. StringConstructor) satisfy

--- a/test/model/relationalProperties.test-d.ts
+++ b/test/model/relationalProperties.test-d.ts
@@ -1,4 +1,4 @@
-import { factory, manyOf, oneOf, primaryKey } from '@mswjs/data'
+import { factory, manyOf, oneOf, primaryKey, nullable } from '@mswjs/data'
 
 const db = factory({
   user: {
@@ -7,7 +7,10 @@ const db = factory({
   },
   post: {
     id: primaryKey(String),
+    text: String,
     author: oneOf('user'),
+    reply: nullable(oneOf('post')),
+    likedBy: nullable(manyOf('user')),
   },
 })
 
@@ -19,3 +22,21 @@ post.author.id
 
 // @ts-expect-error posts is potentially undefined
 user.posts[0]
+
+// @ts-expect-error reply is potentially null
+post.reply.id
+
+// @ts-expect-error likedBy is potentially null
+post.likedBy.length
+
+// nullable oneOf relationships are not potentially undefined, only null
+if (post.reply !== null) {
+  // we can call reply.text.toUpperCase after excluding null from types
+  post.reply.text.toUpperCase()
+}
+
+// nullable manyOf relationships are not potentially undefined, only null
+if (post.likedBy !== null) {
+  // we can call likedBy.pop after excluding null from types
+  post.likedBy.pop()
+}


### PR DESCRIPTION
I made a mistake when updating #158 after we merged #143, it is not actually possible for nullable relationships to be `undefined`, they are `null` instead. Sorry I let that slip by!

This is purely for proper annotation similarly to #158 

It is not possible for the value of nullable relations to be undefined because:
- if the relation does not have an initial value it defaults to null.
- it is not possible to update the relation's value to be undefined after the fact.
