### PR TITLE
chore: use mswjs for GitHub sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-github: kettanaito
+github: mswjs
 open_collective: mswjs


### PR DESCRIPTION
Use the [MSW GitHub Sponsors profile](https://github.com/sponsors/mswjs) for the "Sponsor" button.