### PR TITLE
fix(manyOf): exclude undefined from non-nullable without value

### DIFF
--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -230,7 +230,7 @@ export type Value<
     Target[Key] extends ManyOf<infer ModelName, infer Nullable>
     ? Nullable extends true
       ? PublicEntity<Dictionary, ModelName>[] | null
-      : PublicEntity<Dictionary, ModelName>[] | undefined
+      : PublicEntity<Dictionary, ModelName>[]
     : // Account for primitive value getters because
     // native constructors (i.e. StringConstructor) satisfy
     // the "AnyObject" predicate below.

--- a/test/model/relationalProperties.test-d.ts
+++ b/test/model/relationalProperties.test-d.ts
@@ -20,9 +20,6 @@ const post = db.post.create()
 // @ts-expect-error author is potentially undefined
 post.author.id
 
-// @ts-expect-error posts is potentially undefined
-user.posts[0]
-
 // @ts-expect-error reply is potentially null
 post.reply.id
 


### PR DESCRIPTION
This PR fixes the typings to match the behavioural update in https://github.com/mswjs/data/pull/201 (#199). 