### PR TITLE
Feat/#203 support nullable nested objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,10 +472,16 @@ When using Typescript, you can manually set the type of the property when it can
 ```typescript
 import { factory, primaryKey, nullable } from '@mswjs/data'
 
+type Car = {
+  brand: string
+  model: string
+}
+
 const db = factory({
   user: {
     id: primaryKey(String),
     age: nullable<number>(() => null),
+    car: nullable<Car>(() => null),
   },
 })
 ```

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -19,7 +19,7 @@ export type KeyType = string | number | symbol
 export type AnyObject = Record<KeyType, any>
 export type PrimaryKeyType = string | number
 export type PrimitiveValueType = string | number | boolean | Date
-export type ModelValueType = PrimitiveValueType | PrimitiveValueType[]
+export type ModelValueType = PrimitiveValueType | PrimitiveValueType[] | Object
 export type ModelValueTypeGetter = () => ModelValueType
 
 export type ModelDefinition = Record<string, ModelDefinitionValue>

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -19,7 +19,10 @@ export type KeyType = string | number | symbol
 export type AnyObject = Record<KeyType, any>
 export type PrimaryKeyType = string | number
 export type PrimitiveValueType = string | number | boolean | Date
-export type ModelValueType = PrimitiveValueType | PrimitiveValueType[] | Object
+export type ModelValueType =
+  | PrimitiveValueType
+  | PrimitiveValueType[]
+  | AnyObject
 export type ModelValueTypeGetter = () => ModelValueType
 
 export type ModelDefinition = Record<string, ModelDefinitionValue>

--- a/src/utils/isModelValueType.ts
+++ b/src/utils/isModelValueType.ts
@@ -10,5 +10,9 @@ function isPrimitiveValueType(value: any): value is PrimitiveValueType {
 }
 
 export function isModelValueType(value: any): value is ModelValueType {
-  return isPrimitiveValueType(value) || Array.isArray(value)
+  return (
+    isPrimitiveValueType(value) ||
+    Array.isArray(value) ||
+    typeof value === 'object'
+  )
 }

--- a/test/model/create.test.ts
+++ b/test/model/create.test.ts
@@ -97,6 +97,56 @@ test('creates a new entity with nullable properties', () => {
   expect(user.address.number).toEqual(null)
 })
 
+test('supports nested nullable object', () => {
+  type Car = {
+    brand: string
+    model: string
+  }
+
+  const db = factory({
+    user: {
+      id: primaryKey(datatype.uuid),
+      name: name.findName,
+      car: nullable<Car>(() => null),
+    },
+  })
+
+  const DIDDY = {
+    id: '🐵',
+    name: 'Diddy',
+    car: {
+      brand: 'Diddy Kong',
+      model: 'Super Racing Model with extra 🍌 carriage',
+    },
+  }
+
+  const diddyUser = db.user.create({
+    id: DIDDY.id,
+    name: DIDDY.name,
+    car: DIDDY.car,
+  })
+
+  expect(diddyUser.id).toEqual(DIDDY.id)
+  expect(diddyUser.name).toEqual(DIDDY.name)
+  expect(diddyUser.car).toEqual(DIDDY.car)
+
+  const DONKEY = {
+    id: '🦍',
+    name: 'Donkey',
+    car: null,
+  }
+
+  const donkeyUser = db.user.create({
+    id: DONKEY.id,
+    name: DONKEY.name,
+    car: DONKEY.car,
+  })
+
+  expect(donkeyUser.id).toEqual(DONKEY.id)
+  expect(donkeyUser.name).toEqual(DONKEY.name)
+  expect(donkeyUser.car).toEqual(DONKEY.car)
+})
+
 test('supports nested objects in the model definition', () => {
   const db = factory({
     user: {

--- a/test/model/create.test.ts
+++ b/test/model/create.test.ts
@@ -102,49 +102,63 @@ test('supports nested nullable object', () => {
     brand: string
     model: string
   }
+  type Bike = Car
 
   const db = factory({
     user: {
       id: primaryKey(datatype.uuid),
       name: name.findName,
-      car: nullable<Car>(() => null),
+      vehicule: {
+        car: nullable<Car>(() => null),
+        bike: nullable<Bike>(() => null),
+      },
     },
   })
 
   const DIDDY = {
     id: '🐵',
     name: 'Diddy',
-    car: {
-      brand: 'Diddy Kong',
-      model: 'Super Racing Model with extra 🍌 carriage',
+    vehicule: {
+      car: {
+        brand: 'Diddy Kong',
+        model: 'Super Racing Model with extra 🍌 carriage',
+      },
     },
   }
 
   const diddyUser = db.user.create({
     id: DIDDY.id,
     name: DIDDY.name,
-    car: DIDDY.car,
+    vehicule: { car: DIDDY.vehicule.car },
   })
 
   expect(diddyUser.id).toEqual(DIDDY.id)
   expect(diddyUser.name).toEqual(DIDDY.name)
-  expect(diddyUser.car).toEqual(DIDDY.car)
+  expect(diddyUser.vehicule.car).toEqual(DIDDY.vehicule.car)
+  expect(diddyUser.vehicule.bike).toEqual(null)
 
   const DONKEY = {
     id: '🦍',
     name: 'Donkey',
-    car: null,
+    vehicule: {
+      car: null,
+      bike: {
+        brand: 'Donkey Kong Choppers',
+        model: 'Chuck Norris, the fastest',
+      },
+    },
   }
 
   const donkeyUser = db.user.create({
     id: DONKEY.id,
     name: DONKEY.name,
-    car: DONKEY.car,
+    vehicule: DONKEY.vehicule,
   })
 
   expect(donkeyUser.id).toEqual(DONKEY.id)
   expect(donkeyUser.name).toEqual(DONKEY.name)
-  expect(donkeyUser.car).toEqual(DONKEY.car)
+  expect(donkeyUser.vehicule.bike).toEqual(DONKEY.vehicule.bike)
+  expect(donkeyUser.vehicule.car).toEqual(null)
 })
 
 test('supports nested objects in the model definition', () => {


### PR DESCRIPTION
This is regarding issue #203 

I have extended the existing `ModelValueType` and the function `isModelValueType`  to allow for `object` type.

I also added a new test case covering the scenario described in #203 .

It was indeed failing at the beginning, the object would be null no matter whether or not you passed to create an existing object. 
This was caused by `isModelValueType` that would return `false` if the object was not a Primitive or an Array of Primitives.

The test is now passing, and I've also tested it manually.

Note that this is my PR for this project and unfortunately the tests were not all green out of the box. So I manually checked where these functions/types were used to ensure I didn't break existing functionalities.

Please don't hesitate to let me know if anything needs to be changed.