### PR TITLE
feat(createMany): add createMany api

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ drop(db)
 Each model has the following methods:
 
 - [`create()`](#create)
+- [`createMany()](#createMany)
 - [`findFirst()`](#findFirst)
 - [`findMany()`](#findMany)
 - [`count()`](#count)
@@ -235,6 +236,24 @@ const user = db.user.create({
 ```
 
 > Note that all model properties _are optional_, including [relational properties](#model-relationships).
+
+### `createMany`
+
+Creates multiple entities for the model.
+
+```js
+const users = db.user.createMany({
+  firstName: 'Alice',
+}, {
+  firstName: 'Bob',
+})
+```
+
+At least one set of initial values must be passed to this method. To create entities using the getter functions specified in the model definition, you can pass empty objects:
+
+```js
+const users = db.user.createMany({}, {}, {}, {})
+```
 
 ### `findFirst`
 

--- a/README.md
+++ b/README.md
@@ -242,17 +242,17 @@ const user = db.user.create({
 Creates multiple entities for the model.
 
 ```js
-const users = db.user.createMany({
+const users = db.user.createMany([{
   firstName: 'Alice',
 }, {
   firstName: 'Bob',
-})
+}])
 ```
 
 At least one set of initial values must be passed to this method. To create entities using the getter functions specified in the model definition, you can pass empty objects:
 
 ```js
-const users = db.user.createMany({}, {}, {}, {})
+const users = db.user.createMany([{}, {}, {}, {}])
 ```
 
 ### `findFirst`

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -102,8 +102,8 @@ function createModelApi<
       db.create(modelName, entity)
       return entity
     },
-    createMany(firstInitialValue, ...otherInitialValues) {
-      return [firstInitialValue, ...otherInitialValues].map(api.create);
+    createMany(initialValues) {
+      return initialValues.map(api.create);
     },
     count(query) {
       if (!query) {

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -102,6 +102,9 @@ function createModelApi<
       db.create(modelName, entity)
       return entity
     },
+    createMany(firstInitialValue, ...otherInitialValues) {
+      return [firstInitialValue, ...otherInitialValues].map(api.create);
+    },
     count(query) {
       if (!query) {
         return db.count(modelName)

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -112,8 +112,7 @@ export interface ModelAPI<
    * Creates multiple entities for the model.
    */
   createMany(
-    firstInitialValue: InitialValues<Dictionary, ModelName>,
-    ...otherInitialValues: InitialValues<Dictionary, ModelName>[]
+    initialValues: [InitialValues<Dictionary, ModelName>, ...InitialValues<Dictionary, ModelName>[]],
   ): Entity<Dictionary, ModelName>[]
   /**
    * Return the total number of entities.

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -109,6 +109,13 @@ export interface ModelAPI<
     initialValues?: InitialValues<Dictionary, ModelName>,
   ): Entity<Dictionary, ModelName>
   /**
+   * Creates multiple entities for the model.
+   */
+  createMany(
+    firstInitialValue: InitialValues<Dictionary, ModelName>,
+    ...otherInitialValues: InitialValues<Dictionary, ModelName>[]
+  ): Entity<Dictionary, ModelName>[]
+  /**
    * Return the total number of entities.
    */
   count(

--- a/test/model/createMany.test-d.ts
+++ b/test/model/createMany.test-d.ts
@@ -21,13 +21,13 @@ const db = factory({
 // Most assertions are covered by create.test-d.ts, as
 // createMany calls it internally
 
-// @ts-expect-error Expected at least 1 arguments, but got 0.
-db.user.createMany()
+// @ts-expect-error Source has 0 element(s) but target requires 1.
+db.user.createMany([])
 
-db.user.createMany(
+db.user.createMany([
   {},
   {
     // @ts-expect-error Property "secondName" does not exist on "user".
     secondName: 'any'
   }
-)
+])

--- a/test/model/createMany.test-d.ts
+++ b/test/model/createMany.test-d.ts
@@ -1,0 +1,33 @@
+import faker from '@faker-js/faker';
+import { factory, nullable, primaryKey } from '../../src';
+
+const db = factory({
+  user: {
+    id: primaryKey(String),
+    firstName: String,
+    lastName: nullable(faker.name.lastName),
+    age: nullable<number>(() => null),
+    address: {
+      billing: {
+        country: String,
+      },
+    },
+  },
+  company: {
+    name: primaryKey(String),
+  },
+})
+
+// Most assertions are covered by create.test-d.ts, as
+// createMany calls it internally
+
+// @ts-expect-error Expected at least 1 arguments, but got 0.
+db.user.createMany()
+
+db.user.createMany(
+  {},
+  {
+    // @ts-expect-error Property "secondName" does not exist on "user".
+    secondName: 'any'
+  }
+)

--- a/test/model/createMany.test.ts
+++ b/test/model/createMany.test.ts
@@ -9,7 +9,7 @@ test('creates a single new entity', () => {
     },
   })
 
-  const users = db.user.createMany({})
+  const users = db.user.createMany([{}])
   expect(users.length).toEqual(1)
   expect(users[0].id).toEqual(userId)
 })
@@ -21,7 +21,7 @@ test('creates multiple new entities', () => {
     },
   })
 
-  const users = db.user.createMany({}, {}, {})
+  const users = db.user.createMany([{}, {}, {}])
   expect(users.length).toEqual(3)
 })
 
@@ -32,13 +32,13 @@ test('creates entities using the set values', () => {
     },
   })
 
-  const users = db.user.createMany({
+  const users = db.user.createMany([{
     id: 'abc-123',
   }, {
     id: 'def-456',
   }, {
     id: 'ghi-789',
-  })
+  }])
   expect(users.length).toEqual(3)
   expect(users[0].id).toEqual('abc-123')
   expect(users[1].id).toEqual('def-456')

--- a/test/model/createMany.test.ts
+++ b/test/model/createMany.test.ts
@@ -1,0 +1,46 @@
+import faker from '@faker-js/faker'
+import { factory, identity, primaryKey } from '../../src'
+
+test('creates a single new entity', () => {
+  const userId = faker.datatype.uuid()
+  const db = factory({
+    user: {
+      id: primaryKey(identity(userId)),
+    },
+  })
+
+  const users = db.user.createMany({})
+  expect(users.length).toEqual(1)
+  expect(users[0].id).toEqual(userId)
+})
+
+test('creates multiple new entities', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(faker.datatype.uuid),
+    },
+  })
+
+  const users = db.user.createMany({}, {}, {})
+  expect(users.length).toEqual(3)
+})
+
+test('creates entities using the set values', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(faker.datatype.uuid),
+    },
+  })
+
+  const users = db.user.createMany({
+    id: 'abc-123',
+  }, {
+    id: 'def-456',
+  }, {
+    id: 'ghi-789',
+  })
+  expect(users.length).toEqual(3)
+  expect(users[0].id).toEqual('abc-123')
+  expect(users[1].id).toEqual('def-456')
+  expect(users[2].id).toEqual('ghi-789')
+})


### PR DESCRIPTION
There have been a few times where I've found it would be useful to pass an array of model definitions to create, so I've added a createMany api. Happy to take direction on improvements, love what you're doing with this!