### PR TITLE
fix(oneOf): identify Nullable type returned from oneOf method

### DIFF
--- a/src/relations/Relation.ts
+++ b/src/relations/Relation.ts
@@ -25,8 +25,8 @@ export enum RelationKind {
   ManyOf = 'MANY_OF',
 }
 
-export interface RelationAttributes {
-  nullable: boolean
+export interface RelationAttributes<Nullable extends boolean = boolean> {
+  nullable: Nullable
   unique: boolean
 }
 

--- a/src/relations/oneOf.ts
+++ b/src/relations/oneOf.ts
@@ -1,9 +1,9 @@
 import { OneOf, Relation, RelationAttributes, RelationKind } from './Relation'
 
-export function oneOf<ModelName extends string>(
+export function oneOf<ModelName extends string, Nullable extends boolean = false>(
   to: ModelName,
-  attributes?: Partial<RelationAttributes>,
-): OneOf<ModelName> {
+  attributes?: Partial<RelationAttributes<Nullable>>,
+): OneOf<ModelName, Nullable> {
   return new Relation({
     to,
     kind: RelationKind.OneOf,


### PR DESCRIPTION
This PR is incomplete, as the ts-expect-error tests are failing in one-to-one test files for create and update. My intention here is for the return value of oneOf to default to `OneOf<ModelType, false>`, and to be `OneOf<ModelType, true>` if you pass `{ nullable: true }`. However, the types I've added seem to not be specific enough, as the default is just `OneOf<ModelType, boolean>` whatever you set. @kettanaito are you able to provide some guidance? If not, I'll try and come back to this another time!