### PR TITLE
feat: add basic OR query

### DIFF
--- a/src/query/executeQuery.ts
+++ b/src/query/executeQuery.ts
@@ -3,6 +3,7 @@ import { Entity, PrimaryKeyType, PRIMARY_KEY } from '../glossary'
 import { compileQuery } from './compileQuery'
 import {
   BulkQueryOptions,
+  isOrQuery,
   QuerySelector,
   WeakQuerySelector,
 } from './queryTypes'
@@ -57,8 +58,9 @@ export function executeQuery(
   const records = db.getModel(modelName)
 
   // Reduce the query scope if there's a query by primary key of the model.
+  const queryWhere = query.where || {}
   const { [primaryKey]: primaryKeyComparator, ...restQueries } =
-    query.where || {}
+    isOrQuery(queryWhere) ? { [primaryKey]: undefined, ...queryWhere } : queryWhere
   log('primary key query', primaryKeyComparator)
 
   const scopedRecords = primaryKeyComparator

--- a/src/query/queryTypes.ts
+++ b/src/query/queryTypes.ts
@@ -29,9 +29,19 @@ export type RecursiveQuerySelectorWhere<Value extends ModelValueType> =
       }
     : never
 
-export type QuerySelectorWhere<EntityType extends AnyObject> = {
+export type NormalQuerySelectorWhere<EntityType extends AnyObject> = {
   [Key in keyof EntityType]?: RecursiveQuerySelectorWhere<EntityType[Key]>
 }
+
+export type OrQuerySelectorWhere<EntityType extends AnyObject> = {
+  OR: Array<QuerySelectorWhere<EntityType>>
+}
+
+export function isOrQuery<EntityType extends AnyObject>(queryWhere: QuerySelectorWhere<EntityType>): queryWhere is OrQuerySelectorWhere<EntityType> {
+  return (queryWhere as OrQuerySelectorWhere<EntityType>).OR !== undefined;
+}
+
+export type QuerySelectorWhere<EntityType extends AnyObject> = OrQuerySelectorWhere<EntityType> | NormalQuerySelectorWhere<EntityType>
 
 export interface WeakQuerySelectorWhere<KeyType extends PrimaryKeyType> {
   [key: string]: Partial<GetQueryFor<KeyType>>

--- a/test/query/or.test.ts
+++ b/test/query/or.test.ts
@@ -38,25 +38,35 @@ const setup = () => {
 test('queries entities based on a boolean value', () => {
   const db = setup()
 
-  const doorsAndWinter = db.book.findMany({
+  const books = db.book.findMany({
     where: {
       OR: [
         {
-          title: {
-            contains: "Doors",
-          },
+          OR: [
+            {
+              title: {
+                contains: 'Doors',
+              },
+            },
+            {
+              title: {
+                equals: 'New Spring',
+              },
+            },
+          ],
         },
         {
           title: {
-            contains: "Winter",
+            contains: 'Winter',
           },
         },
       ],
     },
   })
-  const doorsAndWinterTitles = doorsAndWinter.map((book) => book.title)
-  expect(doorsAndWinterTitles).toEqual([
+  const bookTitles = books.map((book) => book.title)
+  expect(bookTitles).toEqual([
     'The Winds of Winter',
+    'New Spring',
     'The Doors of Stone',
   ])
 })

--- a/test/query/or.test.ts
+++ b/test/query/or.test.ts
@@ -1,0 +1,62 @@
+import { faker } from '@faker-js/faker'
+import { factory, primaryKey, nullable } from '../../src'
+
+const setup = () => {
+  const db = factory({
+    book: {
+      id: primaryKey(faker.datatype.uuid),
+      title: String,
+      published: Boolean,
+      finished: nullable<boolean>(() => null),
+    },
+  })
+
+  db.book.create({
+    title: 'The Winds of Winter',
+    published: false,
+    finished: false,
+  })
+  db.book.create({
+    title: 'New Spring',
+    published: true,
+    finished: true,
+  })
+  db.book.create({
+    title: 'The Doors of Stone',
+    published: false,
+    finished: null, // Who knows with Patrick?
+  })
+  db.book.create({
+    title: 'The Fellowship of the Ring',
+    published: true,
+    finished: true,
+  })
+
+  return db
+}
+
+test('queries entities based on a boolean value', () => {
+  const db = setup()
+
+  const doorsAndWinter = db.book.findMany({
+    where: {
+      OR: [
+        {
+          title: {
+            contains: "Doors",
+          },
+        },
+        {
+          title: {
+            contains: "Winter",
+          },
+        },
+      ],
+    },
+  })
+  const doorsAndWinterTitles = doorsAndWinter.map((book) => book.title)
+  expect(doorsAndWinterTitles).toEqual([
+    'The Winds of Winter',
+    'The Doors of Stone',
+  ])
+})


### PR DESCRIPTION
Hi, I wanted to take a crack at this issue here: https://github.com/mswjs/data/issues/89

I've made a very basic POC that just adds the ability to do an OR query on the first level, haven't made it work recursively yet, only made sure that the type checks pass and the test I created passes.

Just wanted to make sure that @kettanaito was okay with the general direction of this PR, and if you have any improvement or suggestions you have for me, especially about the types, because quite frankly I'm not a Typescript expert, and the code style as well.

Next would probably be making this actually recursive, and then trying to add AND as well.