### PR TITLE
feat(query): add gt/gte/lt/lte to string comparators

### DIFF
--- a/src/comparators/string.ts
+++ b/src/comparators/string.ts
@@ -13,6 +13,18 @@ export const stringComparators: QueryToComparator<StringQuery> = {
   notContains(expected, actual) {
     return !stringComparators.contains(expected, actual)
   },
+  gt(expected, actual) {
+    return actual > expected
+  },
+  gte(expected, actual) {
+    return actual >= expected
+  },
+  lt(expected, actual) {
+    return actual < expected
+  },
+  lte(expected, actual) {
+    return actual <= expected
+  },
   in(expected, actual) {
     return expected.includes(actual)
   },

--- a/src/query/queryTypes.ts
+++ b/src/query/queryTypes.ts
@@ -110,6 +110,10 @@ export interface StringQuery {
   notEquals: string
   contains: string
   notContains: string
+  gt: string
+  gte: string
+  lt: string
+  lte: string
   in: string[]
   notIn: string[]
 }

--- a/test/comparators/number-comparators.test.ts
+++ b/test/comparators/number-comparators.test.ts
@@ -39,7 +39,7 @@ test('gte', () => {
   expect(numberComparators.gte(4, 2)).toEqual(false)
 })
 
-test('gt', () => {
+test('lt', () => {
   expect(numberComparators.lt(5, 2)).toEqual(true)
   expect(numberComparators.lt(20, 9)).toEqual(true)
   expect(numberComparators.lt(20, 20)).toEqual(false)

--- a/test/comparators/string-comparators.test.ts
+++ b/test/comparators/string-comparators.test.ts
@@ -22,6 +22,106 @@ test('notContains', () => {
   expect(stringComparators.notContains('foo', 'footer')).toBe(false)
 })
 
+test('gt', () => {
+  expect(stringComparators.gt('bar', 'foo')).toEqual(true)
+  expect(stringComparators.gt('001', '002')).toEqual(true)
+  expect(stringComparators.gt('foo', 'footer')).toEqual(true)
+  expect(
+    stringComparators.gt(
+      'c971d070-9b87-5492-9df6-b53091ae3874',
+      'c9ac1210-e5e9-5422-acad-1839535989fe',
+    ),
+  ).toEqual(true)
+  expect(
+    stringComparators.gt(
+      '2022-01-01T15:00:00.000Z',
+      '2022-01-01T15:00:00.001Z',
+    ),
+  ).toEqual(true)
+  expect(stringComparators.gt('foo', 'foo')).toEqual(false)
+  expect(
+    stringComparators.gt(
+      'c9ac1210-e5e9-5422-acad-1839535989fe',
+      'c971d070-9b87-5492-9df6-b53091ae3874',
+    ),
+  ).toEqual(false)
+  expect(
+    stringComparators.gt(
+      '2022-01-01T15:00:00.000Z',
+      '2022-01-01T14:00:00.000Z',
+    ),
+  ).toEqual(false)
+})
+
+test('gte', () => {
+  expect(stringComparators.gte('bar', 'foo')).toEqual(true)
+  expect(stringComparators.gte('001', '002')).toEqual(true)
+  expect(stringComparators.gte('foo', 'footer')).toEqual(true)
+  expect(
+    stringComparators.gte(
+      '2022-01-01T15:00:00.000Z',
+      '2022-01-01T15:00:00.000Z',
+    ),
+  ).toEqual(true)
+  expect(
+    stringComparators.gte(
+      '2022-01-01T15:00:00.000Z',
+      '2022-01-01T14:00:00.000Z',
+    ),
+  ).toEqual(false)
+  expect(stringComparators.gte('footer', 'foot')).toEqual(false)
+})
+
+test('lt', () => {
+  expect(stringComparators.lt('foo', 'bar')).toEqual(true)
+  expect(stringComparators.lt('002', '001')).toEqual(true)
+  expect(stringComparators.lt('footer', 'foo')).toEqual(true)
+  expect(
+    stringComparators.lt(
+      'c9ac1210-e5e9-5422-acad-1839535989fe',
+      'c971d070-9b87-5492-9df6-b53091ae3874',
+    ),
+  ).toEqual(true)
+  expect(
+    stringComparators.lt(
+      '2022-01-01T15:00:00.001Z',
+      '2022-01-01T15:00:00.000Z',
+    ),
+  ).toEqual(true)
+  expect(stringComparators.lt('abc', 'abc')).toEqual(false)
+  expect(
+    stringComparators.lt(
+      'c971d070-9b87-5492-9df6-b53091ae3874',
+      'c9ac1210-e5e9-5422-acad-1839535989fe',
+    ),
+  ).toEqual(false)
+  expect(
+    stringComparators.lt(
+      '2022-01-01T14:00:00.000Z',
+      '2022-01-01T15:00:00.000Z',
+    ),
+  ).toEqual(false)
+})
+
+test('lte', () => {
+  expect(stringComparators.lte('foo', 'bar')).toEqual(true)
+  expect(stringComparators.lte('002', '001')).toEqual(true)
+  expect(stringComparators.lte('footer', 'foot')).toEqual(true)
+  expect(
+    stringComparators.lte(
+      '2022-01-01T14:00:00.000Z',
+      '2022-01-01T14:00:00.000Z',
+    ),
+  ).toEqual(true)
+  expect(
+    stringComparators.lte(
+      '2022-01-01T14:00:00.000Z',
+      '2022-01-01T15:00:00.000Z',
+    ),
+  ).toEqual(false)
+  expect(stringComparators.lte('foot', 'footer')).toEqual(false)
+})
+
 test('in', () => {
   expect(stringComparators.in(['a', 'foo'], 'a')).toBe(true)
   expect(stringComparators.in(['a', 'foo'], 'foo')).toBe(true)

--- a/test/model/toGraphQLSchema.test.ts
+++ b/test/model/toGraphQLSchema.test.ts
@@ -35,6 +35,10 @@ test('generates a graphql schema', () => {
       notEquals: ID
       contains: ID
       notContains: ID
+      gt: ID
+      gte: ID
+      lt: ID
+      lte: ID
       in: [ID]
       notIn: [ID]
     }
@@ -44,6 +48,10 @@ test('generates a graphql schema', () => {
       notEquals: String
       contains: String
       notContains: String
+      gt: String
+      gte: String
+      lt: String
+      lte: String
       in: [String]
       notIn: [String]
     }


### PR DESCRIPTION
Adds the ability to perform greater than, greater than or equal to, less than and less than or equal to operators on string data values.

In addition, fixed a typo in the number test suite for the description of `lt` comparators.

Discussion: https://github.com/mswjs/data/discussions/244