### PR TITLE
feat: created nullable object option without getter

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -149,7 +149,6 @@ function createModelApi<
     update({ strict, ...query }) {
       const results = executeQuery(modelName, primaryKey, query, db)
       const prevRecord = first(results)
-      // console.log('results: ', results)
 
       if (!prevRecord) {
         if (strict) {

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -149,6 +149,7 @@ function createModelApi<
     update({ strict, ...query }) {
       const results = executeQuery(modelName, primaryKey, query, db)
       const prevRecord = first(results)
+      // console.log('results: ', results)
 
       if (!prevRecord) {
         if (strict) {

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -226,7 +226,7 @@ export type Value<
     Target[Key] extends NullableProperty<any>
     ? ReturnType<Target[Key]['getValue']>
     : Target[Key] extends NullableObject<any>
-    ? Partial<Value<ReturnType<Target[Key]['getObjectDefinition']>, Dictionary>>
+    ? Partial<Value<Target[Key]['objectDefinition'], Dictionary>> | null
     : // Extract value type from OneOf relations.
     Target[Key] extends OneOf<infer ModelName, infer Nullable>
     ? Nullable extends true

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -226,7 +226,7 @@ export type Value<
     Target[Key] extends NullableProperty<any>
     ? ReturnType<Target[Key]['getValue']>
     : Target[Key] extends NullableObject<any>
-    ? Partial<Value<ReturnType<Target[Key]['getValue']>, Dictionary>>
+    ? Partial<Value<ReturnType<Target[Key]['getObjectDefinition']>, Dictionary>>
     : // Extract value type from OneOf relations.
     Target[Key] extends OneOf<infer ModelName, infer Nullable>
     ? Nullable extends true

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -43,8 +43,6 @@ export type NestedModelDefinition = {
     | NestedModelDefinition
 }
 
-export type NullableNestedModelDefinition = NestedModelDefinition | null
-
 export type FactoryAPI<Dictionary extends Record<string, any>> = {
   [ModelName in keyof Dictionary]: ModelAPI<Dictionary, ModelName>
 } & {

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -1,7 +1,7 @@
 import { GraphQLSchema } from 'graphql'
 import { GraphQLHandler, RestHandler } from 'msw'
 import { Database } from './db/Database'
-import { NullableProperty } from './nullable'
+import { NullableObject, NullableProperty } from './nullable'
 import { PrimaryKey } from './primaryKey'
 import {
   BulkQueryOptions,
@@ -28,6 +28,7 @@ export type ModelDefinitionValue =
   | PrimaryKey<any>
   | ModelValueTypeGetter
   | NullableProperty<any>
+  | NullableObject<any>
   | OneOf<any, boolean>
   | ManyOf<any, boolean>
   | NestedModelDefinition
@@ -36,10 +37,13 @@ export type NestedModelDefinition = {
   [propertyName: string]:
     | ModelValueTypeGetter
     | NullableProperty<any>
+    | NullableObject<any>
     | OneOf<any, boolean>
     | ManyOf<any, boolean>
     | NestedModelDefinition
 }
+
+export type NullableNestedModelDefinition = NestedModelDefinition | null
 
 export type FactoryAPI<Dictionary extends Record<string, any>> = {
   [ModelName in keyof Dictionary]: ModelAPI<Dictionary, ModelName>
@@ -221,6 +225,8 @@ export type Value<
     : // Extract underlying value type of nullable properties
     Target[Key] extends NullableProperty<any>
     ? ReturnType<Target[Key]['getValue']>
+    : Target[Key] extends NullableObject<any>
+    ? Partial<Value<ReturnType<Target[Key]['getValue']>, Dictionary>>
     : // Extract value type from OneOf relations.
     Target[Key] extends OneOf<infer ModelName, infer Nullable>
     ? Nullable extends true

--- a/src/model/createModel.ts
+++ b/src/model/createModel.ts
@@ -79,16 +79,15 @@ export function createModel<
       }
 
       if (propertyDefinition instanceof NullableObject) {
-        if (initialValue === null) {
-          // in case the initial value of the nullable object is null, we want
-          // to override the inner values of the object and set the
-          // object itself to be null
+        if (
+          initialValue === null ||
+          (propertyDefinition.defaultsToNull && initialValue === undefined)
+        ) {
+          // this is for all the cases we want to override the inner values of
+          // the nullable object and just set it to be null. it happens when:
+          // 1. the initial value of the nullable object is null
+          // 2. the initial value of the nullable object is not defined and the definition defaults to null
           set(properties, propertyName, null)
-        } else if (propertyDefinition.getValue() === null) {
-          // in case the definition of the nullable object defaults to null
-          const valueToInitialize =
-            initialValue === undefined ? null : initialValue
-          set(properties, propertyName, valueToInitialize)
         }
         return properties
       }

--- a/src/model/getDefinition.ts
+++ b/src/model/getDefinition.ts
@@ -8,10 +8,6 @@ export function getDefinition(
   propertyName: string[],
 ) {
   return propertyName.reduce((reducedDefinition, property) => {
-    if (reducedDefinition === null) {
-      // this is for the case where NullableObject definition defaults to null
-      return
-    }
     const value = reducedDefinition[property]
 
     if (value instanceof NullableProperty) {
@@ -19,16 +15,17 @@ export function getDefinition(
     }
 
     if (value instanceof NullableObject) {
-      // in case the value which is NullableObject is NOT in the last position in the propertyName array
-      // we want to get its value and continue the reduce loop to get its children definition
+      // in case the propertyName array includes NullableObject, we get
+      // the NullableObject definition and continue the reduce loop
       if (property !== propertyName.at(-1)) {
-        return value.getValue()
+        return value.getObjectDefinition()
       }
-      // if it is in the last position of the propertyName array, just return it to the caller at createModel
+      // in case the propertyName array ends with NullableObject, we just return it and if
+      // it should get the value of null, it will override its inner properties
       return value
     }
 
-    // this is for getter functions (String, Number or () => 'some value') and nested objects
+    // getter functions and nested objects
     if (isFunction(value) || isObject(value)) {
       return value
     }

--- a/src/model/getDefinition.ts
+++ b/src/model/getDefinition.ts
@@ -1,0 +1,38 @@
+import { NullableObject, NullableProperty } from '../nullable'
+import { ModelDefinition } from '../glossary'
+import { isObject } from '../utils/isObject'
+import { isFunction } from 'lodash'
+
+export function getDefinition(
+  definition: ModelDefinition,
+  propertyName: string[],
+) {
+  return propertyName.reduce((reducedDefinition, property) => {
+    if (reducedDefinition === null) {
+      // this is for the case where NullableObject definition defaults to null
+      return
+    }
+    const value = reducedDefinition[property]
+
+    if (value instanceof NullableProperty) {
+      return value
+    }
+
+    if (value instanceof NullableObject) {
+      // in case the value which is NullableObject is NOT in the last position in the propertyName array
+      // we want to get its value and continue the reduce loop to get its children definition
+      if (property !== propertyName.at(-1)) {
+        return value.getValue()
+      }
+      // if it is in the last position of the propertyName array, just return it to the caller at createModel
+      return value
+    }
+
+    // this is for getter functions (String, Number or () => 'some value') and nested objects
+    if (isFunction(value) || isObject(value)) {
+      return value
+    }
+
+    return
+  }, definition)
+}

--- a/src/model/getDefinition.ts
+++ b/src/model/getDefinition.ts
@@ -18,7 +18,7 @@ export function getDefinition(
       // in case the propertyName array includes NullableObject, we get
       // the NullableObject definition and continue the reduce loop
       if (property !== propertyName.at(-1)) {
-        return value.getObjectDefinition()
+        return value.objectDefinition
       }
       // in case the propertyName array ends with NullableObject, we just return it and if
       // it should get the value of null, it will override its inner properties

--- a/src/model/parseModelDefinition.ts
+++ b/src/model/parseModelDefinition.ts
@@ -80,7 +80,7 @@ function deepParseModelDefinition<Dictionary extends ModelDictionary>(
       deepParseModelDefinition(
         dictionary,
         modelName,
-        value.getObjectDefinition(),
+        value.objectDefinition,
         propertyPath,
         result,
       )

--- a/src/model/parseModelDefinition.ts
+++ b/src/model/parseModelDefinition.ts
@@ -9,7 +9,7 @@ import {
 import { PrimaryKey } from '../primaryKey'
 import { isObject } from '../utils/isObject'
 import { Relation, RelationsList } from '../relations/Relation'
-import { NullableProperty } from '../nullable'
+import { NullableObject, NullableProperty } from '../nullable'
 
 const log = debug('parseModelDefinition')
 
@@ -72,6 +72,23 @@ function deepParseModelDefinition<Dictionary extends ModelDictionary>(
 
     if (value instanceof NullableProperty) {
       // Add nullable properties to the same list as regular properties
+      result.properties.push(propertyPath)
+      continue
+    }
+
+    if (value instanceof NullableObject) {
+      const objectDefinition = value.getValue()
+      // if the object definition is not null, make a recursive call
+      if (objectDefinition !== null) {
+        deepParseModelDefinition(
+          dictionary,
+          modelName,
+          objectDefinition,
+          propertyPath,
+          result,
+        )
+      }
+
       result.properties.push(propertyPath)
       continue
     }

--- a/src/model/parseModelDefinition.ts
+++ b/src/model/parseModelDefinition.ts
@@ -77,18 +77,16 @@ function deepParseModelDefinition<Dictionary extends ModelDictionary>(
     }
 
     if (value instanceof NullableObject) {
-      const objectDefinition = value.getValue()
-      // if the object definition is not null, make a recursive call
-      if (objectDefinition !== null) {
-        deepParseModelDefinition(
-          dictionary,
-          modelName,
-          objectDefinition,
-          propertyPath,
-          result,
-        )
-      }
+      deepParseModelDefinition(
+        dictionary,
+        modelName,
+        value.getObjectDefinition(),
+        propertyPath,
+        result,
+      )
 
+      // after the recursion calls we want to set the nullable object itself to be part of the properties
+      // because in case it will get the value of null we want to override its inner values
       result.properties.push(propertyPath)
       continue
     }

--- a/src/model/updateEntity.ts
+++ b/src/model/updateEntity.ts
@@ -173,15 +173,6 @@ export function updateEntity(
         continue
       }
 
-      if (
-        propertyDefinition instanceof NullableObject &&
-        propertyDefinition.getValue() === null
-      ) {
-        // in case the NullableObject definition is null
-        set(nextEntity, propertyPath, nextValue)
-        continue
-      }
-
       // Support updating nested objects.
       if (isObject(nextValue)) {
         log(

--- a/src/model/updateEntity.ts
+++ b/src/model/updateEntity.ts
@@ -53,7 +53,6 @@ export function updateEntity(
       }
 
       if (propertyDefinition instanceof Relation) {
-        console.log('in relation')
         log(
           'property "%s" is a "%s" relationship to "%s"',
           propertyPath,
@@ -204,7 +203,6 @@ export function updateEntity(
       )
 
       log('updating a plain property "%s" to:', propertyPath, nextValue)
-
       set(nextEntity, propertyPath, nextValue)
     }
   }

--- a/src/nullable.ts
+++ b/src/nullable.ts
@@ -1,20 +1,12 @@
 import { ModelValueType, NullableNestedModelDefinition } from './glossary'
 import { ManyOf, OneOf, Relation, RelationKind } from './relations/Relation'
-import { isObject } from './utils/isObject'
-
-export type NullableNestedGetter<
-  ValueType extends NullableNestedModelDefinition,
-> = () => ValueType | null
 
 export class NullableObject<ValueType extends NullableNestedModelDefinition> {
-  public getObjectDefinition: NullableNestedGetter<ValueType>
+  public objectDefinition: ValueType
   public defaultsToNull: boolean
 
-  constructor(
-    getter: NullableNestedGetter<ValueType>,
-    defaultsToNull: boolean,
-  ) {
-    this.getObjectDefinition = getter
+  constructor(definition: ValueType, defaultsToNull: boolean) {
+    this.objectDefinition = definition
     this.defaultsToNull = defaultsToNull
   }
 }
@@ -70,7 +62,7 @@ export function nullable(
   }
 
   if (typeof value === 'object') {
-    return new NullableObject(() => value, !!options?.defaultsToNull)
+    return new NullableObject(value, !!options?.defaultsToNull)
   }
 
   if (typeof value === 'function') {

--- a/src/nullable.ts
+++ b/src/nullable.ts
@@ -32,17 +32,19 @@ export class NullableProperty<ValueType extends ModelValueType> {
 
 export function nullable<ValueType extends NullableNestedModelDefinition>(
   value: ValueType,
-  defaultsToNull?: boolean,
+  options?: { defaultsToNull?: boolean },
 ): NullableObject<ValueType>
 
 export function nullable<ValueType extends ModelValueType>(
   value: NullableGetter<ValueType>,
+  options?: { defaultsToNull?: boolean },
 ): NullableProperty<ValueType>
 
 export function nullable<
   ValueType extends Relation<any, any, any, { nullable: false }>,
 >(
   value: ValueType,
+  options?: { defaultsToNull?: boolean },
 ): ValueType extends Relation<infer Kind, infer Key, any, { nullable: false }>
   ? Kind extends RelationKind.ManyOf
     ? ManyOf<Key, true>
@@ -54,7 +56,7 @@ export function nullable(
     | NullableGetter<ModelValueType>
     | Relation<any, any, any, { nullable: false }>
     | NullableNestedModelDefinition,
-  defaultsToNull?: boolean,
+  options?: { defaultsToNull?: boolean },
 ) {
   if (value instanceof Relation) {
     return new Relation({
@@ -67,8 +69,8 @@ export function nullable(
     })
   }
 
-  if (typeof value === 'object' || value === null) {
-    return new NullableObject(() => value, !!defaultsToNull)
+  if (typeof value === 'object') {
+    return new NullableObject(() => value, !!options?.defaultsToNull)
   }
 
   if (typeof value === 'function') {

--- a/src/nullable.ts
+++ b/src/nullable.ts
@@ -1,16 +1,35 @@
-import { ModelValueType } from './glossary'
+import { ModelValueType, NullableNestedModelDefinition } from './glossary'
 import { ManyOf, OneOf, Relation, RelationKind } from './relations/Relation'
+import { isObject } from './utils/isObject'
+
+export type NullableNestedGetter<
+  ValueType extends NullableNestedModelDefinition,
+> = () => ValueType | null
+
+export class NullableObject<ValueType extends NullableNestedModelDefinition> {
+  public getValue: NullableNestedGetter<ValueType>
+
+  constructor(getter: NullableNestedGetter<ValueType>) {
+    this.getValue = getter
+  }
+}
 
 export type NullableGetter<ValueType extends ModelValueType> =
   () => ValueType | null
 
 export class NullableProperty<ValueType extends ModelValueType> {
   public getValue: NullableGetter<ValueType>
+  public isGetterFunctionReturningObject: boolean
 
   constructor(getter: NullableGetter<ValueType>) {
     this.getValue = getter
+    this.isGetterFunctionReturningObject = isObject(getter)
   }
 }
+
+export function nullable<ValueType extends NullableNestedModelDefinition>(
+  value: ValueType,
+): NullableObject<ValueType>
 
 export function nullable<ValueType extends ModelValueType>(
   value: NullableGetter<ValueType>,
@@ -29,18 +48,25 @@ export function nullable<
 export function nullable(
   value:
     | NullableGetter<ModelValueType>
-    | Relation<any, any, any, { nullable: false }>,
+    | Relation<any, any, any, { nullable: false }>
+    | NullableNestedModelDefinition,
 ) {
+  if (value instanceof Relation) {
+    return new Relation({
+      kind: value.kind,
+      to: value.target.modelName,
+      attributes: {
+        ...value.attributes,
+        nullable: true,
+      },
+    })
+  }
+
+  if (typeof value === 'object' || value === null) {
+    return new NullableObject(() => value)
+  }
+
   if (typeof value === 'function') {
     return new NullableProperty(value)
   }
-
-  return new Relation({
-    kind: value.kind,
-    to: value.target.modelName,
-    attributes: {
-      ...value.attributes,
-      nullable: true,
-    },
-  })
 }

--- a/src/nullable.ts
+++ b/src/nullable.ts
@@ -1,7 +1,7 @@
-import { ModelValueType, NullableNestedModelDefinition } from './glossary'
+import { ModelValueType, NestedModelDefinition } from './glossary'
 import { ManyOf, OneOf, Relation, RelationKind } from './relations/Relation'
 
-export class NullableObject<ValueType extends NullableNestedModelDefinition> {
+export class NullableObject<ValueType extends NestedModelDefinition> {
   public objectDefinition: ValueType
   public defaultsToNull: boolean
 
@@ -22,7 +22,7 @@ export class NullableProperty<ValueType extends ModelValueType> {
   }
 }
 
-export function nullable<ValueType extends NullableNestedModelDefinition>(
+export function nullable<ValueType extends NestedModelDefinition>(
   value: ValueType,
   options?: { defaultsToNull?: boolean },
 ): NullableObject<ValueType>
@@ -47,7 +47,7 @@ export function nullable(
   value:
     | NullableGetter<ModelValueType>
     | Relation<any, any, any, { nullable: false }>
-    | NullableNestedModelDefinition,
+    | NestedModelDefinition,
   options?: { defaultsToNull?: boolean },
 ) {
   if (value instanceof Relation) {

--- a/src/nullable.ts
+++ b/src/nullable.ts
@@ -7,10 +7,15 @@ export type NullableNestedGetter<
 > = () => ValueType | null
 
 export class NullableObject<ValueType extends NullableNestedModelDefinition> {
-  public getValue: NullableNestedGetter<ValueType>
+  public getObjectDefinition: NullableNestedGetter<ValueType>
+  public defaultsToNull: boolean
 
-  constructor(getter: NullableNestedGetter<ValueType>) {
-    this.getValue = getter
+  constructor(
+    getter: NullableNestedGetter<ValueType>,
+    defaultsToNull: boolean,
+  ) {
+    this.getObjectDefinition = getter
+    this.defaultsToNull = defaultsToNull
   }
 }
 
@@ -19,16 +24,15 @@ export type NullableGetter<ValueType extends ModelValueType> =
 
 export class NullableProperty<ValueType extends ModelValueType> {
   public getValue: NullableGetter<ValueType>
-  public isGetterFunctionReturningObject: boolean
 
   constructor(getter: NullableGetter<ValueType>) {
     this.getValue = getter
-    this.isGetterFunctionReturningObject = isObject(getter)
   }
 }
 
 export function nullable<ValueType extends NullableNestedModelDefinition>(
   value: ValueType,
+  defaultsToNull?: boolean,
 ): NullableObject<ValueType>
 
 export function nullable<ValueType extends ModelValueType>(
@@ -50,6 +54,7 @@ export function nullable(
     | NullableGetter<ModelValueType>
     | Relation<any, any, any, { nullable: false }>
     | NullableNestedModelDefinition,
+  defaultsToNull?: boolean,
 ) {
   if (value instanceof Relation) {
     return new Relation({
@@ -63,7 +68,7 @@ export function nullable(
   }
 
   if (typeof value === 'object' || value === null) {
-    return new NullableObject(() => value)
+    return new NullableObject(() => value, !!defaultsToNull)
   }
 
   if (typeof value === 'function') {

--- a/test/model/create.test.ts
+++ b/test/model/create.test.ts
@@ -379,7 +379,7 @@ describe('nullable objects with null definition', () => {
             street: String,
             number: nullable(Number),
           },
-          true,
+          { defaultsToNull: true },
         ),
       },
     })
@@ -406,7 +406,7 @@ describe('nullable objects with null definition', () => {
             street: String,
             number: nullable(Number),
           },
-          true,
+          { defaultsToNull: true },
         ),
       },
     })
@@ -427,7 +427,7 @@ describe('nullable objects with null definition', () => {
             street: String,
             number: nullable(Number),
           },
-          true,
+          { defaultsToNull: true },
         ),
       },
     })
@@ -447,7 +447,7 @@ describe('nullable objects with null definition', () => {
             street: String,
             number: nullable(Number),
           },
-          true,
+          { defaultsToNull: true },
         ),
       },
     })
@@ -600,7 +600,7 @@ describe('nullable objects with complex structure and null definition', () => {
               number: nullable(() => 100),
             }),
           },
-          true,
+          { defaultsToNull: true },
         ),
       },
     })
@@ -639,7 +639,7 @@ describe('nullable objects with complex structure and null definition', () => {
               number: nullable(() => 100),
             }),
           },
-          true,
+          { defaultsToNull: true },
         ),
       },
     })
@@ -664,7 +664,7 @@ describe('nullable objects with complex structure and null definition', () => {
               number: nullable(() => 100),
             }),
           },
-          true,
+          { defaultsToNull: true },
         ),
       },
     })
@@ -688,7 +688,7 @@ describe('nullable objects with complex structure and null definition', () => {
               number: nullable(() => 100),
             }),
           },
-          true,
+          { defaultsToNull: true },
         ),
       },
     })

--- a/test/model/create.test.ts
+++ b/test/model/create.test.ts
@@ -257,21 +257,6 @@ test('throws an exception when null used as initial value for non-nullable relat
   )
 })
 
-type AddressDefinitionType = {
-  street: StringConstructor
-  number: NullableProperty<number>
-}
-
-type NullableAddressDefinitionType = AddressDefinitionType | null
-
-type UserDetailsType = {
-  name: StringConstructor
-  hobbies: ArrayConstructor
-  address: NullableObject<AddressDefinitionType>
-}
-
-type NullableUserDetailsType = UserDetailsType | null
-
 describe('nullable objects with regular definition', () => {
   test('full initial value', () => {
     const db = factory({
@@ -389,7 +374,13 @@ describe('nullable objects with null definition', () => {
     const db = factory({
       user: {
         id: primaryKey(faker.datatype.uuid),
-        address: nullable<NullableAddressDefinitionType>(null),
+        address: nullable(
+          {
+            street: String,
+            number: nullable(Number),
+          },
+          true,
+        ),
       },
     })
 
@@ -410,7 +401,13 @@ describe('nullable objects with null definition', () => {
     const db = factory({
       user: {
         id: primaryKey(faker.datatype.uuid),
-        address: nullable<NullableAddressDefinitionType>(null),
+        address: nullable(
+          {
+            street: String,
+            number: nullable(Number),
+          },
+          true,
+        ),
       },
     })
 
@@ -425,7 +422,13 @@ describe('nullable objects with null definition', () => {
     const db = factory({
       user: {
         id: primaryKey(faker.datatype.uuid),
-        address: nullable<NullableAddressDefinitionType>(null),
+        address: nullable(
+          {
+            street: String,
+            number: nullable(Number),
+          },
+          true,
+        ),
       },
     })
 
@@ -439,7 +442,13 @@ describe('nullable objects with null definition', () => {
     const db = factory({
       user: {
         id: primaryKey(faker.datatype.uuid),
-        address: nullable<NullableAddressDefinitionType>(null),
+        address: nullable(
+          {
+            street: String,
+            number: nullable(Number),
+          },
+          true,
+        ),
       },
     })
 
@@ -582,7 +591,17 @@ describe('nullable objects with complex structure and null definition', () => {
     const db = factory({
       user: {
         id: primaryKey(faker.datatype.uuid),
-        details: nullable<NullableUserDetailsType>(null),
+        details: nullable(
+          {
+            name: String,
+            hobbies: Array,
+            address: nullable({
+              street: () => 'Wall street',
+              number: nullable(() => 100),
+            }),
+          },
+          true,
+        ),
       },
     })
 
@@ -611,7 +630,17 @@ describe('nullable objects with complex structure and null definition', () => {
     const db = factory({
       user: {
         id: primaryKey(faker.datatype.uuid),
-        details: nullable<NullableUserDetailsType>(null),
+        details: nullable(
+          {
+            name: String,
+            hobbies: Array,
+            address: nullable({
+              street: () => 'Wall street',
+              number: nullable(() => 100),
+            }),
+          },
+          true,
+        ),
       },
     })
 
@@ -626,7 +655,17 @@ describe('nullable objects with complex structure and null definition', () => {
     const db = factory({
       user: {
         id: primaryKey(faker.datatype.uuid),
-        details: nullable<NullableUserDetailsType>(null),
+        details: nullable(
+          {
+            name: String,
+            hobbies: Array,
+            address: nullable({
+              street: () => 'Wall street',
+              number: nullable(() => 100),
+            }),
+          },
+          true,
+        ),
       },
     })
 
@@ -640,7 +679,17 @@ describe('nullable objects with complex structure and null definition', () => {
     const db = factory({
       user: {
         id: primaryKey(faker.datatype.uuid),
-        details: nullable<NullableUserDetailsType>(null),
+        details: nullable(
+          {
+            name: String,
+            hobbies: Array,
+            address: nullable({
+              street: () => 'Wall street',
+              number: nullable(() => 100),
+            }),
+          },
+          true,
+        ),
       },
     })
 

--- a/test/model/update.test.ts
+++ b/test/model/update.test.ts
@@ -782,7 +782,7 @@ describe('updating nullable objects with null definition', () => {
             street: String,
             number: nullable(Number),
           },
-          true,
+          { defaultsToNull: true },
         ),
       },
     })
@@ -832,7 +832,7 @@ describe('updating nullable objects with null definition', () => {
             street: String,
             number: nullable(Number),
           },
-          true,
+          { defaultsToNull: true },
         ),
       },
     })
@@ -876,7 +876,7 @@ describe('updating nullable objects with null definition', () => {
             street: String,
             number: nullable(Number),
           },
-          true,
+          { defaultsToNull: true },
         ),
       },
     })
@@ -920,7 +920,7 @@ describe('updating nullable objects with null definition', () => {
             street: String,
             number: nullable(Number),
           },
-          true,
+          { defaultsToNull: true },
         ),
       },
     })

--- a/test/model/update.test.ts
+++ b/test/model/update.test.ts
@@ -3,6 +3,7 @@ import { factory, oneOf, primaryKey, nullable } from '../../src'
 import { ENTITY_TYPE, PRIMARY_KEY } from '../../src/glossary'
 import { OperationErrorType } from '../../src/errors/OperationError'
 import { getThrownError } from '../testUtils'
+import { NullableProperty } from '../../src/nullable'
 
 test('updates a unique entity that matches the query', () => {
   const userId = faker.datatype.uuid()
@@ -592,4 +593,348 @@ test('throws when setting a non-nullable property to null', () => {
   ).toThrow(
     'Failed to update "firstName" on "user": cannot set a non-nullable property to null.',
   )
+})
+
+type AddressDefinitionType = {
+  street: StringConstructor
+  number: NullableProperty<number>
+}
+
+type NullableAddressDefinitionType = AddressDefinitionType | null
+
+describe('updating nullable objects with regular definition', () => {
+  const userId = 'abc-123'
+  test('update full initial value to other non null values', () => {
+    const db = factory({
+      user: {
+        id: primaryKey(faker.datatype.uuid),
+        address: nullable({
+          street: String,
+          number: nullable(Number),
+        }),
+      },
+    })
+
+    const user = db.user.create({
+      id: userId,
+      address: {
+        street: 'Wall street',
+        number: 100,
+      },
+    })
+
+    expect(user.address).toEqual({
+      street: 'Wall street',
+      number: 100,
+    })
+
+    db.user.update({
+      where: { id: { equals: userId } },
+      data: {
+        address: {
+          street: 'Fifth Avenue',
+          number: 500,
+        },
+      },
+    })
+
+    const userResult = db.user.findFirst({
+      where: {
+        id: {
+          equals: userId,
+        },
+      },
+    })
+
+    expect(userResult?.address).toEqual({
+      street: 'Fifth Avenue',
+      number: 500,
+    })
+  })
+  test('update full initial value to null', () => {
+    const db = factory({
+      user: {
+        id: primaryKey(faker.datatype.uuid),
+        address: nullable({
+          street: String,
+          number: nullable(Number),
+        }),
+      },
+    })
+
+    const user = db.user.create({
+      id: userId,
+      address: {
+        street: 'Wall street',
+        number: 100,
+      },
+    })
+
+    expect(user.address).toEqual({
+      street: 'Wall street',
+      number: 100,
+    })
+
+    db.user.update({
+      where: { id: { equals: userId } },
+      data: {
+        address: null,
+      },
+    })
+
+    const userResult = db.user.findFirst({
+      where: {
+        id: {
+          equals: userId,
+        },
+      },
+    })
+
+    expect(userResult?.address).toEqual(null)
+  })
+  test('update null initial value to non null value', () => {
+    const db = factory({
+      user: {
+        id: primaryKey(faker.datatype.uuid),
+        address: nullable({
+          street: String,
+          number: nullable(Number),
+        }),
+      },
+    })
+
+    const user = db.user.create({
+      id: userId,
+      address: null,
+    })
+
+    expect(user.address).toEqual(null)
+
+    db.user.update({
+      where: { id: { equals: userId } },
+      data: {
+        address: {
+          street: 'Fifth Avenue',
+          number: 500,
+        },
+      },
+    })
+
+    const userResult = db.user.findFirst({
+      where: {
+        id: {
+          equals: userId,
+        },
+      },
+    })
+
+    expect(userResult?.address).toEqual({
+      street: 'Fifth Avenue',
+      number: 500,
+    })
+  })
+  test('update no initial value to non null value', () => {
+    const db = factory({
+      user: {
+        id: primaryKey(faker.datatype.uuid),
+        address: nullable({
+          street: String,
+          number: nullable(Number),
+        }),
+      },
+    })
+
+    const user = db.user.create({
+      id: userId,
+    })
+
+    expect(user.address).toEqual({
+      street: '',
+      number: 0,
+    })
+
+    db.user.update({
+      where: { id: { equals: userId } },
+      data: {
+        address: {
+          street: 'Fifth Avenue',
+          number: 500,
+        },
+      },
+    })
+
+    const userResult = db.user.findFirst({
+      where: {
+        id: {
+          equals: userId,
+        },
+      },
+    })
+
+    expect(userResult?.address).toEqual({
+      street: 'Fifth Avenue',
+      number: 500,
+    })
+  })
+})
+
+describe('updating nullable objects with null definition', () => {
+  const userId = 'abc-123'
+  test('update full initial value to other non null values', () => {
+    const db = factory({
+      user: {
+        id: primaryKey(faker.datatype.uuid),
+        address: nullable<NullableAddressDefinitionType>(null),
+      },
+    })
+
+    const user = db.user.create({
+      id: userId,
+      address: {
+        street: 'Wall street',
+        number: 100,
+      },
+    })
+
+    expect(user.address).toEqual({
+      street: 'Wall street',
+      number: 100,
+    })
+
+    db.user.update({
+      where: { id: { equals: userId } },
+      data: {
+        address: {
+          street: 'Fifth Avenue',
+          number: 500,
+        },
+      },
+    })
+
+    const userResult = db.user.findFirst({
+      where: {
+        id: {
+          equals: userId,
+        },
+      },
+    })
+
+    expect(userResult?.address).toEqual({
+      street: 'Fifth Avenue',
+      number: 500,
+    })
+  })
+  test('update full initial value to null', () => {
+    const db = factory({
+      user: {
+        id: primaryKey(faker.datatype.uuid),
+        address: nullable<NullableAddressDefinitionType>(null),
+      },
+    })
+
+    const user = db.user.create({
+      id: userId,
+      address: {
+        street: 'Wall street',
+        number: 100,
+      },
+    })
+
+    expect(user.address).toEqual({
+      street: 'Wall street',
+      number: 100,
+    })
+
+    db.user.update({
+      where: { id: { equals: userId } },
+      data: {
+        address: null,
+      },
+    })
+
+    const userResult = db.user.findFirst({
+      where: {
+        id: {
+          equals: userId,
+        },
+      },
+    })
+
+    expect(userResult?.address).toEqual(null)
+  })
+  test('update null initial value to non null value', () => {
+    const db = factory({
+      user: {
+        id: primaryKey(faker.datatype.uuid),
+        address: nullable<NullableAddressDefinitionType>(null),
+      },
+    })
+
+    const user = db.user.create({
+      id: userId,
+      address: null,
+    })
+
+    expect(user.address).toEqual(null)
+
+    db.user.update({
+      where: { id: { equals: userId } },
+      data: {
+        address: {
+          street: 'Fifth Avenue',
+          number: 500,
+        },
+      },
+    })
+
+    const userResult = db.user.findFirst({
+      where: {
+        id: {
+          equals: userId,
+        },
+      },
+    })
+
+    expect(userResult?.address).toEqual({
+      street: 'Fifth Avenue',
+      number: 500,
+    })
+  })
+  test('update no initial value to non null value', () => {
+    const db = factory({
+      user: {
+        id: primaryKey(faker.datatype.uuid),
+        address: nullable<NullableAddressDefinitionType>(null),
+      },
+    })
+
+    const user = db.user.create({
+      id: userId,
+    })
+
+    expect(user.address).toEqual(null)
+
+    db.user.update({
+      where: { id: { equals: userId } },
+      data: {
+        address: {
+          street: 'Fifth Avenue',
+          number: 500,
+        },
+      },
+    })
+
+    const userResult = db.user.findFirst({
+      where: {
+        id: {
+          equals: userId,
+        },
+      },
+    })
+
+    expect(userResult?.address).toEqual({
+      street: 'Fifth Avenue',
+      number: 500,
+    })
+  })
 })

--- a/test/model/update.test.ts
+++ b/test/model/update.test.ts
@@ -595,13 +595,6 @@ test('throws when setting a non-nullable property to null', () => {
   )
 })
 
-type AddressDefinitionType = {
-  street: StringConstructor
-  number: NullableProperty<number>
-}
-
-type NullableAddressDefinitionType = AddressDefinitionType | null
-
 describe('updating nullable objects with regular definition', () => {
   const userId = 'abc-123'
   test('update full initial value to other non null values', () => {
@@ -784,7 +777,13 @@ describe('updating nullable objects with null definition', () => {
     const db = factory({
       user: {
         id: primaryKey(faker.datatype.uuid),
-        address: nullable<NullableAddressDefinitionType>(null),
+        address: nullable(
+          {
+            street: String,
+            number: nullable(Number),
+          },
+          true,
+        ),
       },
     })
 
@@ -828,7 +827,13 @@ describe('updating nullable objects with null definition', () => {
     const db = factory({
       user: {
         id: primaryKey(faker.datatype.uuid),
-        address: nullable<NullableAddressDefinitionType>(null),
+        address: nullable(
+          {
+            street: String,
+            number: nullable(Number),
+          },
+          true,
+        ),
       },
     })
 
@@ -866,7 +871,13 @@ describe('updating nullable objects with null definition', () => {
     const db = factory({
       user: {
         id: primaryKey(faker.datatype.uuid),
-        address: nullable<NullableAddressDefinitionType>(null),
+        address: nullable(
+          {
+            street: String,
+            number: nullable(Number),
+          },
+          true,
+        ),
       },
     })
 
@@ -904,7 +915,13 @@ describe('updating nullable objects with null definition', () => {
     const db = factory({
       user: {
         id: primaryKey(faker.datatype.uuid),
-        address: nullable<NullableAddressDefinitionType>(null),
+        address: nullable(
+          {
+            street: String,
+            number: nullable(Number),
+          },
+          true,
+        ),
       },
     })
 


### PR DESCRIPTION
This PR is for supporting nullable objects without a getter function (mentioned in [issue 203](https://github.com/mswjs/data/issues/203))

I took some inspiration from @roertbb solution, but solved it a little bit differently. I haven't changed the ModelValueType definition but rather made a new NullableObject class that accepts a value of the type NestedModelDefinition, since this is in fact what it should receive. It also accepts a second arg that indicates if the NullableObject should default to null (I made it so that the complete object definition will always be given while creating an instance of the class)

In general, I think that @kettanaito request [here](https://github.com/mswjs/data/issues/203#issue-1197709742) to implement it without a getter function makes a lot of sense as it is more consistent with regular nested objects (because we don't define them with a getter function as well)