### PR TITLE
feat: support relative paths when generating rest handlers

### DIFF
--- a/src/model/generateRestHandlers.ts
+++ b/src/model/generateRestHandlers.ts
@@ -31,8 +31,9 @@ type RequestParams<Key extends PrimaryKeyType> = {
 
 export function createUrlBuilder(baseUrl?: string) {
   return (path: string) => {
-    const url = new URL(path, baseUrl || 'http://localhost')
-    return baseUrl ? url.toString() : url.pathname
+    // For the previous implementation trailing slash didn't matter, we must keep it this way for backward compatibility
+    const normalizedBaseUrl = baseUrl && baseUrl.slice(-1) === '/' ? baseUrl.slice(0, -1) : baseUrl || '';
+    return `${normalizedBaseUrl}/${path}`
   }
 }
 

--- a/test/utils/generateRestHandlers.test.ts
+++ b/test/utils/generateRestHandlers.test.ts
@@ -1,5 +1,5 @@
 import { response, restContext } from 'msw'
-import { primaryKey } from '../..'
+import { primaryKey } from '../../src'
 import { ModelDefinition } from '../../src/glossary'
 import {
   OperationError,
@@ -15,12 +15,22 @@ import {
 describe('createUrlBuilder', () => {
   it('builds a relative URL given no base URL', () => {
     const buildUrl = createUrlBuilder()
-    expect(buildUrl('/users')).toEqual('/users')
+    expect(buildUrl('users')).toEqual('/users')
+  })
+
+  it('builds a relative URL given a prefix as a base URL', () => {
+    const buildUrl = createUrlBuilder('/api/v1')
+    expect(buildUrl('users')).toEqual('/api/v1/users')
   })
 
   it('builds an absolute URL given a base URL', () => {
     const buildUrl = createUrlBuilder('https://example.com')
-    expect(buildUrl('/users')).toEqual('https://example.com/users')
+    expect(buildUrl('users')).toEqual('https://example.com/users')
+  })
+
+  it('builds an absolute URL given a base URL with trailing slash', () => {
+    const buildUrl = createUrlBuilder('https://example.com/')
+    expect(buildUrl('users')).toEqual('https://example.com/users')
   })
 })
 


### PR DESCRIPTION
Removes usage of URL constructor in `createUrlBuilder` which is used for generating REST handlers.
Approach with strings concatenation allows us to use relative paths without specific hostnames, provide prefixes, and also use parameters in the baseUrl that will be handled by MSW.

I also added removing trailing slashes from the baseUrl, as previously it could be passed with and without it and won't affect the result, so I keep it like it was to avoid breaking changes.
Additionally updated tests for the function: removed the leading slash. Because `buildUrl` calls inside `generateRestHandlers` have no leading shashes so tests weren't exactly correct.

(ref: #267)