### PR TITLE
feat: upgrade strict-event-emitter to 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "md5": "^2.3.0",
     "outvariant": "^1.2.1",
     "pluralize": "^8.0.0",
-    "strict-event-emitter": "^0.2.0",
+    "strict-event-emitter": "^0.5.0",
     "uuid": "^8.3.1"
   },
   "optionalDependencies": {

--- a/src/db/Database.ts
+++ b/src/db/Database.ts
@@ -1,6 +1,6 @@
 import md5 from 'md5'
 import { invariant } from 'outvariant'
-import { Emitter, EventMap } from 'strict-event-emitter'
+import { Emitter } from 'strict-event-emitter'
 import {
   Entity,
   ENTITY_TYPE,

--- a/src/model/generateGraphQLHandlers.ts
+++ b/src/model/generateGraphQLHandlers.ts
@@ -57,7 +57,11 @@ function createComparatorGraphQLInputType(
     name,
     fields: Object.keys(comparators).reduce<GraphQLInputFieldConfigMap>(
       (fields, comparatorFn) => {
-        const fieldType = ['between', 'notBetween', 'in', 'notIn'].includes(comparatorFn) ? new GraphQLList(type) : type
+        const fieldType = ['between', 'notBetween', 'in', 'notIn'].includes(
+          comparatorFn,
+        )
+          ? new GraphQLList(type)
+          : type
         fields[comparatorFn] = { type: fieldType }
         return fields
       },

--- a/src/model/generateRestHandlers.ts
+++ b/src/model/generateRestHandlers.ts
@@ -32,7 +32,10 @@ type RequestParams<Key extends PrimaryKeyType> = {
 export function createUrlBuilder(baseUrl?: string) {
   return (path: string) => {
     // For the previous implementation trailing slash didn't matter, we must keep it this way for backward compatibility
-    const normalizedBaseUrl = baseUrl && baseUrl.slice(-1) === '/' ? baseUrl.slice(0, -1) : baseUrl || '';
+    const normalizedBaseUrl =
+      baseUrl && baseUrl.slice(-1) === '/'
+        ? baseUrl.slice(0, -1)
+        : baseUrl || ''
     return `${normalizedBaseUrl}/${path}`
   }
 }

--- a/src/utils/iteratorUtils.ts
+++ b/src/utils/iteratorUtils.ts
@@ -1,4 +1,4 @@
-import { PrimaryKeyType } from "../glossary"
+import { PrimaryKeyType } from '../glossary'
 
 export function forEach<K extends PrimaryKeyType, V>(
   fn: (key: K, value: V) => any,

--- a/test/db/events.test.ts
+++ b/test/db/events.test.ts
@@ -19,7 +19,7 @@ test('emits the "create" event when a new entity is created', (done) => {
     user: dictionary.user,
   })
 
-  db.events.on('create', (id, [modelName, entity, primaryKey]) => {
+  db.events.on('create', (id, modelName, entity, primaryKey) => {
     expect(id).toEqual(db.id)
     expect(modelName).toEqual('user')
     expect(entity).toEqual({
@@ -69,7 +69,7 @@ test('emits the "update" event when an existing entity is updated', (done) => {
     user: dictionary.user,
   })
 
-  db.events.on('update', (id, [modelName, prevEntity, nextEntity]) => {
+  db.events.on('update', (id, modelName, prevEntity, nextEntity) => {
     expect(id).toEqual(db.id)
     expect(modelName).toEqual('user')
     expect(prevEntity).toEqual({
@@ -133,7 +133,7 @@ test('emits the "delete" event when an existing entity is deleted', (done) => {
     user: dictionary.user,
   })
 
-  db.events.on('delete', (id, [modelName, primaryKey]) => {
+  db.events.on('delete', (id, modelName, primaryKey) => {
     expect(id).toEqual(db.id)
     expect(modelName).toEqual('user')
     expect(primaryKey).toEqual('abc-123')

--- a/yarn.lock
+++ b/yarn.lock
@@ -814,7 +814,7 @@
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
   integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
 
-"@types/debug@^4.1.5", "@types/debug@^4.1.7":
+"@types/debug@^4.1.7":
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
   integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
@@ -5474,6 +5474,11 @@ strict-event-emitter@^0.2.0:
   integrity sha512-zv7K2egoKwkQkZGEaH8m+i2D0XiKzx5jNsiSul6ja2IYFvil10A59Z9Y7PPAAe5OW53dQUf9CfsHKzjZzKkm1w==
   dependencies:
     events "^3.3.0"
+
+strict-event-emitter@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.5.0.tgz#a4aa84a3d9b4a9be12e750a75e089cabb3dbc0e2"
+  integrity sha512-sqnMpVJLSB3daNO6FcvsEk4Mq5IJeAwDeH80DP1S8+pgxrF6yZnE1+VeapesGled7nEcIkz1Ax87HzaIy+02kA==
 
 string-length@^4.0.1:
   version "4.0.2"


### PR DESCRIPTION
I faced the same problem as https://github.com/mswjs/http-middleware/issues/27.

This problem caused by `strict-event-emitter` version.
In another repositories uses higher than v0.4.3 so version but in this repository one is v0.2.0.

New API named `Emitter` is used from v0.3.2 and `StrictEventEmitter` was removed from v0.4.0.


