### PR TITLE
feat: make oneOf relation required if non-nullable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 lib
 *.log
+.idea

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -229,7 +229,7 @@ export type Value<
     Target[Key] extends OneOf<infer ModelName, infer Nullable>
     ? Nullable extends true
       ? PublicEntity<Dictionary, ModelName> | null
-      : PublicEntity<Dictionary, ModelName> | undefined
+      : PublicEntity<Dictionary, ModelName>
     : // Extract value type from ManyOf relations.
     Target[Key] extends ManyOf<infer ModelName, infer Nullable>
     ? Nullable extends true

--- a/test/model/create.test.ts
+++ b/test/model/create.test.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker'
-import { NullableObject, NullableProperty } from '../../src/nullable'
 import { factory, primaryKey, oneOf, manyOf, nullable } from '../../src'
 import { identity } from '../../src/utils/identity'
 
@@ -708,4 +707,24 @@ describe('nullable objects with complex structure and null definition', () => {
       address: null,
     })
   })
+})
+
+test('throws an exception when value is not provided for a non-nullable oneOf relation', () => {
+  const db = factory({
+    user: {
+      id: primaryKey(String),
+      city: oneOf('city'),
+    },
+    city: {
+      id: primaryKey(String),
+    },
+  })
+
+  expect(() => {
+    db.user.create({
+      id: 'user-1',
+    })
+  }).toThrowError(
+    'Failed to define a "ONE_OF" relationship to "city" at "user.city" (id: "user-1"): a value must be provided for a non-nullable relationship.',
+  )
 })

--- a/test/model/relationalProperties.test-d.ts
+++ b/test/model/relationalProperties.test-d.ts
@@ -8,7 +8,7 @@ const db = factory({
   post: {
     id: primaryKey(String),
     text: String,
-    author: oneOf('user'),
+    author: nullable(oneOf('user')),
     reply: nullable(oneOf('post')),
     likedBy: nullable(manyOf('user')),
   },
@@ -17,7 +17,7 @@ const db = factory({
 const user = db.user.create()
 const post = db.post.create()
 
-// @ts-expect-error author is potentially undefined
+// @ts-expect-error author is potentially null
 post.author.id
 
 // @ts-expect-error reply is potentially null

--- a/test/model/relationalProperties.test.ts
+++ b/test/model/relationalProperties.test.ts
@@ -5,7 +5,7 @@ import {
   RelationsList,
 } from '../../src/relations/Relation'
 import { defineRelationalProperties } from '../../src/model/defineRelationalProperties'
-import { testFactory } from '../../test/testUtils'
+import { testFactory } from '../testUtils'
 
 it('marks relational properties as enumerable', () => {
   const { db, dictionary, databaseInstance } = testFactory({
@@ -27,6 +27,7 @@ it('marks relational properties as enumerable', () => {
   const post = db.post.create({
     id: 'post-1',
     title: 'Test Post',
+    author: user,
   })
 
   const relations: RelationsList = [

--- a/test/relations/bi-directional.test.ts
+++ b/test/relations/bi-directional.test.ts
@@ -1,13 +1,13 @@
 /**
  * @see https://github.com/mswjs/data/issues/139
  */
-import { factory, manyOf, oneOf, primaryKey } from '@mswjs/data'
+import { factory, manyOf, oneOf, primaryKey, nullable } from '@mswjs/data'
 
 test('supports creating a bi-directional one-to-one relationship', () => {
   const db = factory({
     user: {
       id: primaryKey(String),
-      partner: oneOf('user'),
+      partner: nullable(oneOf('user')),
     },
   })
 
@@ -117,7 +117,7 @@ test('supports querying by a bi-directional one-to-one relationship', () => {
   const db = factory({
     user: {
       id: primaryKey(String),
-      partner: oneOf('user'),
+      partner: nullable(oneOf('user'))
     },
   })
 
@@ -202,8 +202,8 @@ test('supports querying by a bi-directional one-to-many relationship', () => {
   })
 
   // Create unrelated user and post to ensure they are not included.
-  db.user.create({ id: 'user-unrelated' })
-  db.post.create({ id: 'post-unrelated' })
+  const unrelatedUser = db.user.create({ id: 'user-unrelated' })
+  db.post.create({ id: 'post-unrelated', author: unrelatedUser })
 
   // Find posts in one-to-many direction
   const posts = db.post.findMany({
@@ -304,7 +304,7 @@ test('supports updating using an entity with a bi-directional one-to-one relatio
   const db = factory({
     user: {
       id: primaryKey(String),
-      partner: oneOf('user'),
+      partner: nullable(oneOf('user')),
     },
   })
 
@@ -343,7 +343,7 @@ test('supports updating using an entity with a bi-directional one-to-many relati
     post: {
       id: primaryKey(String),
       title: String,
-      author: oneOf('user'),
+      author: nullable(oneOf('user')),
     },
   })
 

--- a/test/relations/many-to-one.test.ts
+++ b/test/relations/many-to-one.test.ts
@@ -325,7 +325,7 @@ test('updates a many-to-one relational property without initial value', () => {
     },
     post: {
       id: primaryKey(String),
-      author: oneOf('user'),
+      author: nullable(oneOf('user')),
     },
   })
 
@@ -423,7 +423,7 @@ test('does not throw any error when a many-to-one entity is created without a re
     post: {
       id: primaryKey(String),
       title: String,
-      author: oneOf('user'),
+      author: nullable(oneOf('user')),
     },
   })
 
@@ -437,6 +437,7 @@ test('does not throw any error when a many-to-one entity is created without a re
     [PRIMARY_KEY]: 'id',
     id: 'post-1',
     title: 'First post',
+    author: null,
   })
 })
 

--- a/test/relations/one-to-one.create.test.ts
+++ b/test/relations/one-to-one.create.test.ts
@@ -231,7 +231,7 @@ it('creates a non-nullable relationship', () => {
   ).toEqual(expectedCountry)
 })
 
-it('creates a non-nullable relationship without the initial value', () => {
+it('forbids creating a non-nullable relationship without the initial value', () => {
   const { db, entity } = testFactory({
     country: {
       code: primaryKey(String),
@@ -242,24 +242,13 @@ it('creates a non-nullable relationship without the initial value', () => {
     },
   })
 
-  const country = db.country.create({
-    code: 'uk',
-  })
-
-  const expectedCountry = entity('country', {
-    code: 'uk',
-    capital: undefined,
-  })
-
-  expect(country).toEqual(expectedCountry)
-  expect(db.country.findFirst({ where: { code: { equals: 'uk' } } })).toEqual(
-    expectedCountry,
+  expect(() =>
+    db.country.create({
+      code: 'uk',
+    })
+  ).toThrow(
+    'Failed to define a "ONE_OF" relationship to "city" at "country.capital" (code: "uk"): a value must be provided for a non-nullable relationship.',
   )
-  expect(
-    db.country.findFirst({
-      where: { capital: { name: { equals: 'Manchester' } } },
-    }),
-  ).toEqual(null)
 })
 
 it('forbids creating a non-nullable relationship with null as initial value', () => {
@@ -348,32 +337,6 @@ it('creates a non-nullable unique relationship with initial value', () => {
       where: { capital: { name: { equals: 'London' } } },
     }),
   ).toEqual(expectedCountry)
-})
-
-it('creates a non-nullable unique relationship without initial value', () => {
-  const { db, entity } = testFactory({
-    country: {
-      code: primaryKey(String),
-      capital: oneOf('city', { unique: true }),
-    },
-    city: {
-      name: primaryKey(String),
-    },
-  })
-
-  const country = db.country.create({
-    code: 'uk',
-  })
-
-  const expectedCountry = entity('country', {
-    code: 'uk',
-    capital: undefined,
-  })
-
-  expect(country).toEqual(expectedCountry)
-  expect(db.country.findFirst({ where: { code: { equals: 'uk' } } })).toEqual(
-    expectedCountry,
-  )
 })
 
 it('forbids creating a unique relationship to already referenced entity', () => {

--- a/test/relations/one-to-one.operations.test.ts
+++ b/test/relations/one-to-one.operations.test.ts
@@ -53,32 +53,6 @@ it('supports querying through a non-nullable relationship with initial value', (
   ).toEqual(null)
 })
 
-it('supports querying through a non-nullable relationship without initial value', () => {
-  const { db } = testFactory({
-    country: {
-      code: primaryKey(String),
-      capital: oneOf('city'),
-    },
-    city: {
-      name: primaryKey(String),
-    },
-  })
-
-  db.country.create({
-    code: 'uk',
-  })
-
-  // Querying through the relationship is permitted
-  // but since it hasn't been set, no queries will match.
-  expect(
-    db.country.findFirst({
-      where: {
-        capital: { name: { equals: 'London' } },
-      },
-    }),
-  ).toEqual(null)
-})
-
 it('supports querying through a deeply nested non-nullable relationship', () => {
   const { db, entity } = testFactory({
     user: {


### PR DESCRIPTION
Solves https://github.com/mswjs/data/issues/269 by making `oneOf` relation required (throwing an error) unless the field is explicitly set to nullable.