### PR TITLE
docs: fix typo in yarn install options

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ When testing API interactions you often need to mock data. Instead of keeping a 
 ```bash
 $ npm install @mswjs/data --save-dev
 # or
-$ yarn add @mswjs/data --save-dev
+$ yarn add @mswjs/data --dev
 ```
 
 ### Describe data


### PR DESCRIPTION
The package is supposed to be a devDependency; yarn add flag was incorrect, installs it as a dependency.