### PR TITLE
fix: add granular exports for extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -777,7 +777,7 @@ Synchronizes collection changes, like creating/updating/deleting records, with t
 
 ```ts
 import { Collection } from '@msw/data'
-import { sync } from '@msw/data/extensions'
+import { sync } from '@msw/data/extensions/sync'
 
 const users = new Collection({
   schema,
@@ -794,7 +794,7 @@ Persist the records in the collection between page reloads.
 
 ```ts
 import { Collection } from '@msw/data'
-import { persist } from '@msw/data/extensions'
+import { persist } from '@msw/data/extensions/persist'
 
 const users = new Collection({
   schema,

--- a/extensions/package.json
+++ b/extensions/package.json
@@ -1,5 +1,15 @@
 {
   "type": "module",
   "main": "./../build/extensions/index.js",
-  "types": "./../build/extensions/index.d.ts"
+  "types": "./../build/extensions/index.d.ts",
+  "exports": {
+    "./sync": {
+      "types": "./../build/extensions/sync.d.ts",
+      "default": "./../build/extensions/sync.js"
+    },
+    "./persist": {
+      "types": "./../build/extensions/persist.d.ts",
+      "default": "./../build/extensions/persist.js"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,14 @@
     "./extensions": {
       "types": "./build/extensions/index.d.ts",
       "default": "./build/extensions/index.js"
+    },
+    "./extensions/sync": {
+      "types": "./build/extensions/sync.d.ts",
+      "default": "./build/extensions/sync.js"
+    },
+    "./extensions/persist": {
+      "types": "./build/extensions/persist.d.ts",
+      "default": "./build/extensions/persist.js"
     }
   },
   "files": [


### PR DESCRIPTION
- Fixes #325 

Extensions should be imported from their own entrypoints to (1) have a minimal footprint on the user's bundle; (2) be self-contained (think browser/node-only extensions). 