### PR TITLE
refactor: replace lodash with es-toolkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,7 @@
   },
   "dependencies": {
     "@standard-schema/spec": "^1.0.0",
-    "@types/lodash-es": "^4.17.12",
-    "lodash-es": "^4.17.21",
+    "es-toolkit": "^1.39.10",
     "mutative": "^1.3.0",
     "outvariant": "^1.4.3",
     "rettime": "^0.7.0"

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1,5 +1,5 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec'
-import { get } from 'lodash-es'
+import { get } from 'es-toolkit/compat';
 import { apply, create as createDraft, type Draft, type Patch } from 'mutative'
 import { invariant, InvariantError } from 'outvariant'
 import { Logger } from '#/src/logger.js'

--- a/src/extensions/persist.ts
+++ b/src/extensions/persist.ts
@@ -1,5 +1,5 @@
 import { invariant } from 'outvariant'
-import { unset } from 'lodash-es'
+import { unset } from 'es-toolkit/compat';
 import { defineExtension } from '#/src/extensions/index.js'
 import {
   Collection,

--- a/src/extensions/sync.ts
+++ b/src/extensions/sync.ts
@@ -1,4 +1,4 @@
-import { set } from 'lodash-es'
+import { set } from 'es-toolkit/compat';
 import { defineExtension } from '#/src/extensions/index.js'
 import {
   kCollectionId,

--- a/src/relation.ts
+++ b/src/relation.ts
@@ -1,6 +1,7 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec'
 import { invariant, format } from 'outvariant'
-import { get, isEqual, set, unset } from 'lodash-es'
+import { isEqual } from 'es-toolkit'
+import { get, set, unset } from 'es-toolkit/compat'
 import {
   kPrimaryKey,
   kRelationMap,

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -1,5 +1,5 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec'
-import { get } from 'lodash-es'
+import { get } from 'es-toolkit/compat';
 import { toDeepEntries } from '#/src/utils.js'
 
 export type SortDirection = 'asc' | 'desc'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { invariant } from 'outvariant'
-import { isPlainObject } from 'lodash-es'
+import { isPlainObject } from 'es-toolkit';
 import { kPrimaryKey, type RecordType } from '#/src/collection.js'
 
 /**


### PR DESCRIPTION
# Replace lodash with es-toolkit

## Summary
This PR replaces lodash dependency with [es-toolkit](https://es-toolkit.dev/), a modern TypeScript-first utility library that provides better type safety and actively maintained codebase.

## Changes
- Replaced lodash imports with es-toolkit equivalents
- Updated package.json dependencies
- All existing functionality preserved

## Benefits
- Better TypeScript support and type inference
- Actively maintained with regular updates
- Modern ESM-first implementation
- Improved developer experience
- Better performance

