### PR TITLE
refactor: compare with `undefined` directly instead of using `typeof`

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -611,7 +611,7 @@ export class Collection<Schema extends StandardSchemaV1> {
     const { take, cursor, skip } = options
 
     invariant(
-      typeof skip !== 'undefined' ? Number.isInteger(skip) && skip >= 0 : true,
+      skip !== undefined ? Number.isInteger(skip) && skip >= 0 : true,
       'Failed to query the collection: expected the "skip" pagination option to be a number larger or equal to 0 but got %j',
       skip,
     )

--- a/src/query.ts
+++ b/src/query.ts
@@ -74,7 +74,7 @@ export class Query<T> {
           return Object.entries(condition).every(([key, selector]) => {
             const actualValue = record[key]
 
-            if (typeof actualValue === 'undefined') {
+            if (actualValue === undefined) {
               return false
             }
 

--- a/src/relation.ts
+++ b/src/relation.ts
@@ -417,7 +417,7 @@ export abstract class Relation {
           returnValue,
         )
 
-        if (typeof returnValue !== 'undefined') {
+        if (returnValue !== undefined) {
           return returnValue
         }
 
@@ -516,7 +516,7 @@ class One extends Relation {
       /**
        * @note `null` is a valid value for nullable relations.
        */
-      if (typeof record !== 'undefined') {
+      if (record !== undefined) {
         return record
       }
     }


### PR DESCRIPTION
compare with `undefined` directly instead of using `typeof` to make more concise and easier to read