### PR TITLE
chore: fix typos, drop redundant `format()`

### DIFF
--- a/src/extensions/persist.ts
+++ b/src/extensions/persist.ts
@@ -2,10 +2,10 @@ import { invariant } from 'outvariant'
 import { unset } from 'es-toolkit/compat'
 import { defineExtension } from '#/src/extensions/index.js'
 import {
-  Collection,
   kCollectionId,
   kPrimaryKey,
   kRelationMap,
+  type Collection,
   type RecordType,
 } from '#/src/collection.js'
 import { Logger } from '#/src/logger.js'
@@ -81,7 +81,7 @@ export function persist() {
         persistedData.collectionId,
       )
 
-      logger.log(`found (${persistedData.records.length}) records to hydate!`)
+      logger.log(`found (${persistedData.records.length}) records to hydrate!`)
 
       await Promise.all(
         persistedData.records.map(async (serializedRecord) => {

--- a/src/extensions/sync.ts
+++ b/src/extensions/sync.ts
@@ -7,7 +7,7 @@ import {
   type Collection,
   type RecordType,
 } from '#/src/collection.js'
-import { Query } from '#/src/query.js'
+import type { Query } from '#/src/query.js'
 import { isObject, type PropertyPath } from '#/src/utils.js'
 import { Logger } from '#/src/logger.js'
 import {

--- a/src/relation.ts
+++ b/src/relation.ts
@@ -1,5 +1,5 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec'
-import { invariant, format } from 'outvariant'
+import { invariant } from 'outvariant'
 import { isEqual } from 'es-toolkit'
 import { get, set, unset } from 'es-toolkit/compat'
 import {
@@ -433,11 +433,7 @@ export abstract class Relation {
       },
       set: () => {
         throw new RelationError(
-          format(
-            'Failed to set property "%s" on collection (%s): relational properties are read-only and can only be updated via collection updates',
-            serializedPath,
-            this.ownerCollection[kCollectionId],
-          ),
+          `Failed to set property "${serializedPath}" on collection (${this.ownerCollection[kCollectionId]}): relational properties are read-only and can only be updated via collection updates`,
           RelationErrorCodes.UNEXPECTED_SET_EXPRESSION,
           this.#createErrorDetails(),
         )


### PR DESCRIPTION
# chore: type-only imports, drop `format`, fix typo

## Summary
- sync: use `import type { Query }`
- relation: remove `outvariant` `format`; use template literal
- persist: fix "hydrate" typo; mark `Collection` as type

No API changes.
