### PR TITLE
docs: use `--save-dev` flag for install in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This library exists to help developers model and query data when testing and dev
 ### Install
 
 ```
-npm i @msw/data
+npm i @msw/data --save-dev
 ```
 
 ### Create collection


### PR DESCRIPTION
This project is for dev and test. I think in install should use the devDependencies install